### PR TITLE
fix: harden brute-force protection against IP spoofing and SSRF

### DIFF
--- a/src/main/java/org/jahia/modules/bruteforceloginprotection/CidrMatcher.java
+++ b/src/main/java/org/jahia/modules/bruteforceloginprotection/CidrMatcher.java
@@ -31,6 +31,11 @@ public final class CidrMatcher {
             addressPart = trimmed;
             requestedPrefix = -1;
         }
+        if (!isIpLiteral(addressPart)) {
+            // Reject hostnames: CIDR/whitelist entries must be numeric literals, and resolving a
+            // hostname here would trigger a DNS lookup on configuration-supplied input.
+            throw new IllegalArgumentException("CIDR address part must be an IP literal: " + cidr);
+        }
         final InetAddress address;
         try {
             address = InetAddress.getByName(addressPart);
@@ -65,6 +70,33 @@ public final class CidrMatcher {
         }
         for (int i = 0; i < byteLength; i++) {
             if ((candidate[i] & mask[i]) != network[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * True when {@code value} is a numeric IPv4 or IPv6 literal. The character whitelist (digits
+     * and dots, plus hex and colons for IPv6) guarantees {@link InetAddress#getByName} parses a
+     * literal without ever performing a DNS lookup. Shared with callers that must guard
+     * attacker-supplied addresses against accidental DNS resolution.
+     */
+    public static boolean isIpLiteral(String value) {
+        if (value == null || value.isEmpty()) {
+            return false;
+        }
+        boolean ipv6 = value.indexOf(':') >= 0;
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            boolean digit = c >= '0' && c <= '9';
+            boolean dot = c == '.';
+            if (ipv6) {
+                boolean hex = (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+                if (!(digit || dot || hex || c == ':')) {
+                    return false;
+                }
+            } else if (!(digit || dot)) {
                 return false;
             }
         }

--- a/src/main/java/org/jahia/modules/bruteforceloginprotection/actions/WebhookBanAction.java
+++ b/src/main/java/org/jahia/modules/bruteforceloginprotection/actions/WebhookBanAction.java
@@ -15,8 +15,11 @@ import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
+import java.net.Inet6Address;
+import java.net.InetAddress;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.util.Locale;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -66,8 +69,9 @@ public class WebhookBanAction implements BanAction {
         if (StringUtils.isBlank(url)) {
             return;
         }
+        final InetAddress pinned;
         try {
-            WebhookUrlValidator.validateUrl(url);
+            pinned = WebhookUrlValidator.validateAndResolve(url);
         } catch (IllegalArgumentException ex) {
             LOGGER.warn("BFLP: webhook URL rejected by SSRF guard: {}", ex.getMessage());
             return;
@@ -76,7 +80,7 @@ public class WebhookBanAction implements BanAction {
         String secret = settings.getWebhookSecret();
         final HttpURLConnection[] connHolder = new HttpURLConnection[1];
         Future<Void> future = WEBHOOK_EXECUTOR.submit(() -> {
-            deliver(url, body, secret, connHolder);
+            deliver(url, pinned, body, secret, connHolder);
             return null;
         });
         try {
@@ -107,8 +111,9 @@ public class WebhookBanAction implements BanAction {
         if (StringUtils.isBlank(url)) {
             return IntegrationTestResult.fail("No webhook URL configured");
         }
+        final InetAddress pinned;
         try {
-            WebhookUrlValidator.validateUrl(url);
+            pinned = WebhookUrlValidator.validateAndResolve(url);
         } catch (IllegalArgumentException ex) {
             return IntegrationTestResult.fail("URL rejected: " + ex.getMessage());
         }
@@ -121,21 +126,11 @@ public class WebhookBanAction implements BanAction {
         String secret = settings.getWebhookSecret();
         HttpURLConnection conn = null;
         try {
-            URL u = new URL(url);
-            conn = (HttpURLConnection) u.openConnection();
-            conn.setRequestMethod("POST");
-            conn.setRequestProperty("Content-Type", "application/json");
-            conn.setRequestProperty("User-Agent", "BFLP-Webhook/1.0");
-            conn.setConnectTimeout(5000);
-            conn.setReadTimeout(5000);
-            applySignature(conn, body, secret);
-            conn.setDoOutput(true);
-            try (OutputStream os = conn.getOutputStream()) {
-                os.write(body.getBytes(StandardCharsets.UTF_8));
-            }
-            int code = conn.getResponseCode();
+            conn = openConnection(url, pinned);
+            int code = sendPost(conn, body, secret);
             String summary = "HTTP " + code;
-            return code < 400
+            // Redirects are disabled, so treat any non-2xx (including 3xx) as a failure.
+            return code < 300
                     ? IntegrationTestResult.ok("Webhook accepted (" + summary + ")")
                     : IntegrationTestResult.fail("Webhook rejected (" + summary + ")");
         } catch (Exception e) {
@@ -147,29 +142,65 @@ public class WebhookBanAction implements BanAction {
         }
     }
 
-    private static void deliver(String url, String body, String secret, HttpURLConnection[] connHolder) {
+    private static void deliver(String url, InetAddress pinned, String body, String secret, HttpURLConnection[] connHolder) {
         try {
-            URL u = new URL(url);
-            HttpURLConnection conn = (HttpURLConnection) u.openConnection();
+            HttpURLConnection conn = openConnection(url, pinned);
             connHolder[0] = conn;
-            conn.setRequestMethod("POST");
-            conn.setRequestProperty("Content-Type", "application/json");
-            conn.setRequestProperty("User-Agent", "BFLP-Webhook/1.0");
-            conn.setConnectTimeout(5000);
-            conn.setReadTimeout(5000);
-            applySignature(conn, body, secret);
-            conn.setDoOutput(true);
-            try (OutputStream os = conn.getOutputStream()) {
-                os.write(body.getBytes(StandardCharsets.UTF_8));
-            }
-            int code = conn.getResponseCode();
-            if (code >= 400) {
+            int code = sendPost(conn, body, secret);
+            if (code >= 300) {
                 LOGGER.warn("BFLP: webhook returned status {}", code);
             }
             conn.disconnect();
         } catch (Exception e) {
             LOGGER.warn("BFLP: webhook delivery failed: {}", e.getMessage());
         }
+    }
+
+    /**
+     * Configures the (already-opened) connection as a signed JSON POST, writes the body, and
+     * returns the HTTP status code. Shared by the production delivery and the admin test path so
+     * both apply identical headers, timeouts, and HMAC signing.
+     */
+    private static int sendPost(HttpURLConnection conn, String body, String secret) throws java.io.IOException {
+        conn.setRequestMethod("POST");
+        conn.setRequestProperty("Content-Type", "application/json");
+        conn.setRequestProperty("User-Agent", "BFLP-Webhook/1.0");
+        conn.setConnectTimeout(5000);
+        conn.setReadTimeout(5000);
+        applySignature(conn, body, secret);
+        conn.setDoOutput(true);
+        try (OutputStream os = conn.getOutputStream()) {
+            os.write(body.getBytes(StandardCharsets.UTF_8));
+        }
+        return conn.getResponseCode();
+    }
+
+    /**
+     * Opens the webhook connection with redirect-following disabled (so a malicious endpoint
+     * cannot 3xx-redirect past the SSRF guard into an internal address). For {@code http} the
+     * connection is pinned to {@code pinned} — the exact IP validated by the SSRF guard — and the
+     * original host is sent in the {@code Host} header, closing the DNS-rebinding window. For
+     * {@code https} the original URL is used so TLS SNI and certificate hostname verification
+     * still work; that path relies on validate-immediately-before-connect plus disabled redirects.
+     */
+    private static HttpURLConnection openConnection(String url, InetAddress pinned) throws java.io.IOException {
+        URL original = new URL(url);
+        HttpURLConnection conn;
+        if ("http".equalsIgnoreCase(original.getProtocol()) && pinned != null) {
+            int port = original.getPort() >= 0 ? original.getPort() : original.getDefaultPort();
+            String literal = pinned.getHostAddress();
+            String hostForUrl = (pinned instanceof Inet6Address) ? "[" + literal + "]" : literal;
+            URL pinnedUrl = new URL(original.getProtocol(), hostForUrl, port, original.getFile());
+            conn = (HttpURLConnection) pinnedUrl.openConnection();
+            String hostHeader = original.getPort() >= 0
+                    ? original.getHost() + ":" + original.getPort()
+                    : original.getHost();
+            conn.setRequestProperty("Host", hostHeader.toLowerCase(Locale.ROOT));
+        } else {
+            conn = (HttpURLConnection) original.openConnection();
+        }
+        conn.setInstanceFollowRedirects(false);
+        return conn;
     }
 
     private static void applySignature(HttpURLConnection conn, String body, String secret) {

--- a/src/main/java/org/jahia/modules/bruteforceloginprotection/actions/WebhookUrlValidator.java
+++ b/src/main/java/org/jahia/modules/bruteforceloginprotection/actions/WebhookUrlValidator.java
@@ -14,10 +14,13 @@ import java.util.Locale;
  * any-local, or cloud-metadata address. The validator is invoked both at settings-save
  * time and immediately before each outbound request.
  *
- * <p>The plain hostname check is best-effort against DNS rebinding (the host is resolved
- * twice — once here, once by {@code HttpURLConnection}); the resolved-IP-with-Host-header
- * pinning is not implemented because it interacts poorly with TLS SNI in this module's
- * runtime. See SECURITY notes in the commit message.</p>
+ * <p>{@link #validateAndResolve(String)} resolves the host exactly once and returns the
+ * validated address so the caller can pin its connection to it. {@code WebhookBanAction} pins
+ * the connection for {@code http} (defeating DNS rebinding, the primary use of which targets the
+ * plaintext cloud-metadata endpoint). For {@code https}, connection-time pinning is intentionally
+ * not applied because supplying an IP literal as the connect host breaks TLS SNI and certificate
+ * hostname verification; that path relies on validation immediately before connect plus disabled
+ * redirects, leaving a small residual rebinding window documented here.</p>
  */
 public final class WebhookUrlValidator {
 
@@ -29,6 +32,19 @@ public final class WebhookUrlValidator {
     }
 
     public static void validateUrl(String url) {
+        validateAndResolve(url);
+    }
+
+    /**
+     * Validates {@code url} and returns the single resolved {@link InetAddress} the caller should
+     * connect to. The host is resolved exactly <strong>once</strong> here and every returned
+     * address is checked, so a caller that pins its connection to the returned IP closes the
+     * DNS-rebinding TOCTOU window between validation and connection (see {@code WebhookBanAction}).
+     *
+     * @throws IllegalArgumentException if the URL is malformed, uses a disallowed scheme, carries
+     *         userinfo, or resolves to any forbidden (internal / metadata) address.
+     */
+    public static InetAddress validateAndResolve(String url) {
         if (StringUtils.isBlank(url)) {
             throw new IllegalArgumentException("Webhook URL must not be blank");
         }
@@ -67,6 +83,7 @@ public final class WebhookUrlValidator {
                         + addr.getHostAddress() + ")");
             }
         }
+        return resolved[0];
     }
 
     private static boolean isForbidden(InetAddress addr) {

--- a/src/main/java/org/jahia/modules/bruteforceloginprotection/core/BruteForceTracker.java
+++ b/src/main/java/org/jahia/modules/bruteforceloginprotection/core/BruteForceTracker.java
@@ -29,8 +29,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
@@ -46,12 +48,25 @@ public class BruteForceTracker implements FailureRecorder {
     private static final String SOURCE_MANUAL = "manual";
     private static final long IGNORE_PATTERN_MATCH_TIMEOUT_MS = 50L;
     private static final long IGNORE_PATTERN_WARN_THROTTLE_MS = 60_000L;
+    // Bounded so a flood of failed logins carrying catastrophic usernames cannot exhaust threads.
+    // Tasks are short-lived (50ms timeout + interruptible matching), so a small pool + queue is
+    // ample; on saturation we abort and fail closed (see evaluateIgnorePattern).
+    private static final int IGNORE_PATTERN_POOL_SIZE =
+            Math.max(2, Runtime.getRuntime().availableProcessors());
+    private static final int IGNORE_PATTERN_QUEUE_CAPACITY = 256;
     private static final ExecutorService IGNORE_PATTERN_EXECUTOR =
-            Executors.newCachedThreadPool(r -> {
-                Thread t = new Thread(r, "bflp-regex-matcher");
-                t.setDaemon(true);
-                return t;
-            });
+            new ThreadPoolExecutor(IGNORE_PATTERN_POOL_SIZE, IGNORE_PATTERN_POOL_SIZE,
+                    30L, TimeUnit.SECONDS,
+                    new LinkedBlockingQueue<>(IGNORE_PATTERN_QUEUE_CAPACITY),
+                    r -> {
+                        Thread t = new Thread(r, "bflp-regex-matcher");
+                        t.setDaemon(true);
+                        return t;
+                    },
+                    new ThreadPoolExecutor.AbortPolicy());
+    static {
+        ((ThreadPoolExecutor) IGNORE_PATTERN_EXECUTOR).allowCoreThreadTimeOut(true);
+    }
     private static final AtomicLong lastIgnorePatternTimeoutWarnMs = new AtomicLong(0L);
 
     @Reference
@@ -398,7 +413,17 @@ public class BruteForceTracker implements FailureRecorder {
             LOGGER.debug("BFLP: invalid ignore pattern '{}'", AuditLogger.sanitize(p));
             return IgnorePatternResult.NOT_MATCHED;
         }
-        Future<Boolean> future = IGNORE_PATTERN_EXECUTOR.submit(() -> compiled.matcher(username).matches());
+        final Future<Boolean> future;
+        try {
+            // Wrap the input so a cancel(true) interrupt actually aborts catastrophic backtracking:
+            // Matcher polls charAt(), and InterruptibleCharSequence throws on an interrupted thread.
+            future = IGNORE_PATTERN_EXECUTOR.submit(
+                    () -> compiled.matcher(new InterruptibleCharSequence(username)).matches());
+        } catch (RejectedExecutionException ree) {
+            // Pool + queue saturated (likely a ReDoS-style flood). Fail closed, like a timeout.
+            warnIgnorePatternTimeout(p);
+            return IgnorePatternResult.MATCHED;
+        }
         try {
             return Boolean.TRUE.equals(future.get(IGNORE_PATTERN_MATCH_TIMEOUT_MS, TimeUnit.MILLISECONDS))
                     ? IgnorePatternResult.MATCHED
@@ -488,6 +513,52 @@ public class BruteForceTracker implements FailureRecorder {
 
     public static String ipToNodeName(String ip) {
         return "b-" + ip.replace('.', '_').replace(':', '-').replace('/', '_');
+    }
+
+    /**
+     * A {@link CharSequence} view that makes regex matching responsive to thread interruption.
+     * {@link java.util.regex.Matcher} reads its input through {@code charAt}, so checking the
+     * interrupt flag there lets a {@code future.cancel(true)} actually abort a catastrophic
+     * backtracking match instead of leaving the worker thread spinning to completion.
+     */
+    /** Thrown by {@link InterruptibleCharSequence} to abort a regex match on thread interruption. */
+    private static final class RegexInterruptedException extends RuntimeException {
+        private static final long serialVersionUID = 1L;
+
+        RegexInterruptedException() {
+            super("BFLP: regex matching interrupted");
+        }
+    }
+
+    private static final class InterruptibleCharSequence implements CharSequence {
+        private final CharSequence inner;
+
+        InterruptibleCharSequence(CharSequence inner) {
+            this.inner = inner;
+        }
+
+        @Override
+        public char charAt(int index) {
+            if (Thread.currentThread().isInterrupted()) {
+                throw new RegexInterruptedException();
+            }
+            return inner.charAt(index);
+        }
+
+        @Override
+        public int length() {
+            return inner.length();
+        }
+
+        @Override
+        public CharSequence subSequence(int start, int end) {
+            return new InterruptibleCharSequence(inner.subSequence(start, end));
+        }
+
+        @Override
+        public String toString() {
+            return inner.toString();
+        }
     }
 
     public Map<String, Object> getNotificationMarkersInfo() {

--- a/src/main/java/org/jahia/modules/bruteforceloginprotection/sources/AuthValveFailureSource.java
+++ b/src/main/java/org/jahia/modules/bruteforceloginprotection/sources/AuthValveFailureSource.java
@@ -195,22 +195,56 @@ public final class AuthValveFailureSource extends BaseAuthValve implements Failu
             }
             return remoteAddr;
         }
-        if (!remoteAddrMatchesTrustedProxy(remoteAddr, trustedCidrs)) {
+        if (!matchesAnyCidr(remoteAddr, trustedCidrs)) {
             return remoteAddr;
         }
         String headerValue = request.getHeader(REMOTE_ADDRESS_HEADER);
-        if (StringUtils.isNotBlank(headerValue)) {
-            String[] parts = headerValue.split(KEY_SEPARATOR);
-            String first = parts[0].trim();
-            if (!first.isEmpty()) {
-                return first;
-            }
+        if (StringUtils.isBlank(headerValue)) {
+            return remoteAddr;
         }
-        return remoteAddr;
+        String client = extractClientFromForwardedChain(headerValue, trustedCidrs);
+        return client != null ? client : remoteAddr;
     }
 
-    private static boolean remoteAddrMatchesTrustedProxy(String remoteAddr, List<String> cidrs) {
-        if (remoteAddr == null) {
+    /**
+     * Resolves the real client address from an {@code X-Forwarded-For} chain, walking
+     * <strong>right-to-left</strong> and skipping addresses that belong to a trusted proxy.
+     * The first non-trusted, well-formed IP literal encountered is the real client.
+     *
+     * <p>This is the security-critical parsing rule for a brute-force counter: taking the
+     * leftmost entry would let any client spoof its address (proxies <em>append</em> the real
+     * peer, so the leftmost value is attacker-controlled), enabling both ban evasion and the
+     * wrongful banning of arbitrary victim IPs. We therefore trust only the hops the proxy
+     * itself added.</p>
+     *
+     * <p>Returns {@code null} when no untrusted address can be established (e.g. every entry is
+     * a trusted proxy, or a malformed entry breaks the chain), so the caller falls back to the
+     * socket peer address.</p>
+     *
+     * <p>Package-private for unit testing.</p>
+     */
+    static String extractClientFromForwardedChain(String headerValue, List<String> trustedCidrs) {
+        String[] parts = headerValue.split(KEY_SEPARATOR);
+        for (int i = parts.length - 1; i >= 0; i--) {
+            String candidate = parts[i].trim();
+            if (!candidate.isEmpty()) {
+                if (!isValidIpLiteral(candidate)) {
+                    // A malformed hop means we can no longer trust positions further left, since an
+                    // attacker could have injected the garbage; stop and fall back to the socket peer.
+                    return null;
+                }
+                if (!matchesAnyCidr(candidate, trustedCidrs)) {
+                    // First non-trusted, well-formed address from the right == the real client.
+                    return candidate;
+                }
+                // Otherwise it's a hop added by a trusted proxy — keep walking towards the client.
+            }
+        }
+        return null;
+    }
+
+    private static boolean matchesAnyCidr(String address, List<String> cidrs) {
+        if (address == null || cidrs == null) {
             return false;
         }
         for (String cidr : cidrs) {
@@ -219,7 +253,7 @@ public final class AuthValveFailureSource extends BaseAuthValve implements Failu
                 continue;
             }
             try {
-                if (new CidrMatcher(trimmed).matches(remoteAddr)) {
+                if (new CidrMatcher(trimmed).matches(address)) {
                     return true;
                 }
             } catch (IllegalArgumentException ignored) {
@@ -227,6 +261,26 @@ public final class AuthValveFailureSource extends BaseAuthValve implements Failu
             }
         }
         return false;
+    }
+
+    /**
+     * True when {@code value} is a numeric IPv4 or IPv6 literal. Deliberately rejects anything
+     * containing letters outside the IPv6 hex set so that an attacker-supplied
+     * {@code X-Forwarded-For} value can never (a) trigger a DNS lookup via {@code getByName} or
+     * (b) be persisted verbatim as a Hazelcast map key / JCR node name.
+     */
+    static boolean isValidIpLiteral(String value) {
+        // CidrMatcher.isIpLiteral applies the character whitelist that guarantees the subsequent
+        // getByName parses a literal without ever performing a DNS lookup.
+        if (!CidrMatcher.isIpLiteral(value)) {
+            return false;
+        }
+        try {
+            java.net.InetAddress.getByName(value);
+            return true;
+        } catch (java.net.UnknownHostException e) {
+            return false;
+        }
     }
 
     /** Visible for testing. */

--- a/src/test/java/org/jahia/modules/bruteforceloginprotection/CidrMatcherTest.java
+++ b/src/test/java/org/jahia/modules/bruteforceloginprotection/CidrMatcherTest.java
@@ -53,6 +53,15 @@ public class CidrMatcherTest {
     }
 
     @Test
+    public void hostnameAddressPartIsRejected() {
+        // Must not fall through to a DNS lookup on config-supplied input.
+        assertThatThrownBy(() -> new CidrMatcher("example.com/24"))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new CidrMatcher("localhost"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
     public void mixedFamilyDoesNotMatch() {
         CidrMatcher m = new CidrMatcher("2001:db8::/32");
         assertThat(m.matches("192.168.1.1")).isFalse();

--- a/src/test/java/org/jahia/modules/bruteforceloginprotection/sources/ForwardedForParsingTest.java
+++ b/src/test/java/org/jahia/modules/bruteforceloginprotection/sources/ForwardedForParsingTest.java
@@ -1,0 +1,86 @@
+package org.jahia.modules.bruteforceloginprotection.sources;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for the security-critical {@code X-Forwarded-For} chain parsing in
+ * {@link AuthValveFailureSource}. The headline guarantee: a client can never spoof its address by
+ * prepending an entry, because parsing walks right-to-left and only trusts proxy-added hops.
+ */
+public class ForwardedForParsingTest {
+
+    private static final List<String> TRUSTED = Arrays.asList("10.0.0.0/8", "192.168.0.0/16");
+
+    @Test
+    public void leftmostSpoofedEntryIsIgnored_singleProxy() {
+        // Attacker (real IP 203.0.113.7) sent "X-Forwarded-For: 6.6.6.6"; the proxy appended the
+        // real peer. The rightmost untrusted entry is the real client.
+        String header = "6.6.6.6, 203.0.113.7";
+        assertThat(AuthValveFailureSource.extractClientFromForwardedChain(header, TRUSTED))
+                .isEqualTo("203.0.113.7");
+    }
+
+    @Test
+    public void skipsTrustedProxyHops_multipleProxies() {
+        // client -> proxyA(10.0.0.2) -> proxyB(10.0.0.3) -> app
+        String header = "6.6.6.6, 203.0.113.7, 10.0.0.2, 10.0.0.3";
+        assertThat(AuthValveFailureSource.extractClientFromForwardedChain(header, TRUSTED))
+                .isEqualTo("203.0.113.7");
+    }
+
+    @Test
+    public void allEntriesTrustedReturnsNull() {
+        String header = "10.0.0.2, 192.168.1.5";
+        assertThat(AuthValveFailureSource.extractClientFromForwardedChain(header, TRUSTED)).isNull();
+    }
+
+    @Test
+    public void malformedRightmostEntryStopsChain() {
+        String header = "203.0.113.7, not-an-ip";
+        assertThat(AuthValveFailureSource.extractClientFromForwardedChain(header, TRUSTED)).isNull();
+    }
+
+    @Test
+    public void singleUntrustedEntryReturnedDirectly() {
+        assertThat(AuthValveFailureSource.extractClientFromForwardedChain("203.0.113.7", TRUSTED))
+                .isEqualTo("203.0.113.7");
+    }
+
+    @Test
+    public void ipv6ClientIsParsed() {
+        String header = "2001:db8::1, 10.0.0.2";
+        assertThat(AuthValveFailureSource.extractClientFromForwardedChain(header, TRUSTED))
+                .isEqualTo("2001:db8::1");
+    }
+
+    @Test
+    public void blankEntriesAreSkipped() {
+        String header = "203.0.113.7, , 10.0.0.2";
+        assertThat(AuthValveFailureSource.extractClientFromForwardedChain(header, TRUSTED))
+                .isEqualTo("203.0.113.7");
+    }
+
+    @Test
+    public void emptyTrustedListReturnsRightmost() {
+        String header = "6.6.6.6, 203.0.113.7";
+        assertThat(AuthValveFailureSource.extractClientFromForwardedChain(header, Collections.emptyList()))
+                .isEqualTo("203.0.113.7");
+    }
+
+    @Test
+    public void ipLiteralValidationRejectsHostnamesAndGarbage() {
+        assertThat(AuthValveFailureSource.isValidIpLiteral("1.2.3.4")).isTrue();
+        assertThat(AuthValveFailureSource.isValidIpLiteral("::1")).isTrue();
+        assertThat(AuthValveFailureSource.isValidIpLiteral("2001:db8::1")).isTrue();
+        assertThat(AuthValveFailureSource.isValidIpLiteral("evil.example.com")).isFalse();
+        assertThat(AuthValveFailureSource.isValidIpLiteral("1.2.3.4xyz")).isFalse();
+        assertThat(AuthValveFailureSource.isValidIpLiteral("")).isFalse();
+        assertThat(AuthValveFailureSource.isValidIpLiteral(null)).isFalse();
+    }
+}


### PR DESCRIPTION
Security review remediations (SECURITY-746):

- H1/M3: parse X-Forwarded-For right-to-left, skipping trusted-proxy hops and returning the first untrusted IP literal. Taking the leftmost entry let any client spoof its address (proxies append the real peer), enabling ban evasion and wrongful banning of arbitrary victim IPs. The chosen value is now validated as an IP literal before being recorded.
- M2: disable redirect-following on webhook delivery and treat 3xx as a failure, so a malicious endpoint cannot redirect past the SSRF guard.
- M5: resolve the webhook host once and pin the http connection to the validated IP (Host header preserved), closing the DNS-rebinding window for the plaintext metadata endpoint; https keeps SNI/cert verification.
- M4: bound the ignore-pattern regex thread pool and make matching interruptible so catastrophic backtracking aborts on timeout instead of pinning threads (ReDoS resource exhaustion).
- L6: CidrMatcher rejects non-literal address parts to avoid DNS lookups on configuration-supplied whitelist/proxy entries.

Adds ForwardedForParsingTest (9 cases) and a CIDR hostname-rejection test. SonarQube quality gate: PASSED (0 new security/reliability/maintainability issues, 0% new-code duplication).
