### PR TITLE
Support review remediation

### DIFF
--- a/src/main/java/org/jahia/modules/bruteforceloginprotection/actions/WebhookBanAction.java
+++ b/src/main/java/org/jahia/modules/bruteforceloginprotection/actions/WebhookBanAction.java
@@ -17,6 +17,8 @@ import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.Inet6Address;
 import java.net.InetAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Locale;
@@ -183,14 +185,14 @@ public class WebhookBanAction implements BanAction {
      * {@code https} the original URL is used so TLS SNI and certificate hostname verification
      * still work; that path relies on validate-immediately-before-connect plus disabled redirects.
      */
-    private static HttpURLConnection openConnection(String url, InetAddress pinned) throws java.io.IOException {
-        URL original = new URL(url);
+    private static HttpURLConnection openConnection(String url, InetAddress pinned) throws java.io.IOException, URISyntaxException {
+        URL original = URI.create(url).toURL();
         HttpURLConnection conn;
         if ("http".equalsIgnoreCase(original.getProtocol()) && pinned != null) {
             int port = original.getPort() >= 0 ? original.getPort() : original.getDefaultPort();
             String literal = pinned.getHostAddress();
             String hostForUrl = (pinned instanceof Inet6Address) ? "[" + literal + "]" : literal;
-            URL pinnedUrl = new URL(original.getProtocol(), hostForUrl, port, original.getFile());
+            URL pinnedUrl = new URI(original.getProtocol(), null, hostForUrl, port, original.getFile(), null, null).toURL();
             conn = (HttpURLConnection) pinnedUrl.openConnection();
             String hostHeader = original.getPort() >= 0
                     ? original.getHost() + ":" + original.getPort()

--- a/src/main/java/org/jahia/modules/bruteforceloginprotection/core/AuditLogger.java
+++ b/src/main/java/org/jahia/modules/bruteforceloginprotection/core/AuditLogger.java
@@ -18,6 +18,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static org.jahia.modules.bruteforceloginprotection.BruteForceLoginProtectionConstants.*;
 
@@ -41,6 +42,14 @@ public class AuditLogger {
     private static final DateTimeFormatter BUCKET_MONTH = DateTimeFormatter.ofPattern("MM");
     private static final DateTimeFormatter BUCKET_DAY = DateTimeFormatter.ofPattern("dd");
 
+    /**
+     * Piggyback trim: after this many writes have accumulated since the last trim, a trim is
+     * triggered inline. This keeps the log bounded even if the periodic sweep in
+     * {@link UnbanScheduler} fires infrequently, while avoiding an O(n) JCR scan on every write.
+     */
+    private static final long TRIM_WRITE_INTERVAL = 50;
+    private final AtomicLong writesSinceTrim = new AtomicLong(0);
+
     public void log(String event, String ip, String jail, String source, String details) {
         try {
             jcrTemplate.doExecuteWithSystemSessionAsUser(null, Constants.EDIT_WORKSPACE, null, session -> {
@@ -57,11 +66,39 @@ public class AuditLogger {
                 if (source != null) entry.setProperty(PROP_AUDIT_SOURCE, source);
                 if (details != null) entry.setProperty(PROP_AUDIT_DETAILS, details);
                 session.save();
-                trimIfNeeded(container);
+                // Trim is deliberately NOT called here on every write (O(n) JCR scan).
+                // The periodic sweep in UnbanScheduler calls trimAuditLog() every 30 s.
+                // As a safety net, piggyback a trim every TRIM_WRITE_INTERVAL writes so the
+                // log stays bounded even under high load between sweeps.
+                if (writesSinceTrim.incrementAndGet() >= TRIM_WRITE_INTERVAL) {
+                    writesSinceTrim.set(0);
+                    trimIfNeeded(container);
+                }
                 return null;
             });
         } catch (RepositoryException e) {
             LOGGER.warn("BFLP: failed to write audit entry: {}", e.getMessage());
+        }
+    }
+
+    /**
+     * Public entry point for the periodic trim sweep called by {@link UnbanScheduler}.
+     * Performs the O(n) full JCR scan only when invoked from the scheduler thread,
+     * not on the hot per-login-failure write path.
+     */
+    public void trimAuditLog() {
+        try {
+            jcrTemplate.doExecuteWithSystemSessionAsUser(null, Constants.EDIT_WORKSPACE, null, session -> {
+                if (!session.nodeExists(AUDIT_NODE_PATH)) {
+                    return null;
+                }
+                JCRNodeWrapper container = session.getNode(AUDIT_NODE_PATH);
+                trimIfNeeded(container);
+                writesSinceTrim.set(0);
+                return null;
+            });
+        } catch (RepositoryException e) {
+            LOGGER.warn("BFLP: failed during periodic audit log trim: {}", e.getMessage());
         }
     }
 

--- a/src/main/java/org/jahia/modules/bruteforceloginprotection/core/BruteForceTracker.java
+++ b/src/main/java/org/jahia/modules/bruteforceloginprotection/core/BruteForceTracker.java
@@ -13,6 +13,7 @@ import org.jahia.modules.bruteforceloginprotection.spi.FailureRecorder;
 import org.jahia.services.content.JCRNodeWrapper;
 import org.jahia.services.content.JCRTemplate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
@@ -94,6 +95,11 @@ public class BruteForceTracker implements FailureRecorder {
 
     public void removeBanAction(BanAction action) {
         banActions.remove(action);
+    }
+
+    @Deactivate
+    public void deactivate() {
+        IGNORE_PATTERN_EXECUTOR.shutdownNow();
     }
 
     public List<BanAction> getBanActions() {

--- a/src/main/java/org/jahia/modules/bruteforceloginprotection/core/SettingsService.java
+++ b/src/main/java/org/jahia/modules/bruteforceloginprotection/core/SettingsService.java
@@ -160,9 +160,14 @@ public class SettingsService {
         if (newSecret == null) {
             // Unchanged from caller's POV. Opportunistically re-encrypt operator-pasted plaintext.
             if (existing != null && !WebhookSecretCodec.isEncrypted(String.valueOf(existing))) {
-                String reEncrypted = WebhookSecretCodec.encrypt(String.valueOf(existing));
-                if (reEncrypted != null) {
-                    props.put(GlobalConfigHolder.CFG_WEBHOOK_SECRET, reEncrypted);
+                try {
+                    String reEncrypted = WebhookSecretCodec.encrypt(String.valueOf(existing));
+                    if (reEncrypted != null) {
+                        props.put(GlobalConfigHolder.CFG_WEBHOOK_SECRET, reEncrypted);
+                    }
+                } catch (IllegalStateException e) {
+                    // Re-encryption is best-effort; skip silently so settings save still succeeds
+                    LOGGER.warn("BFLP: opportunistic re-encryption of existing secret skipped: {}", e.getMessage());
                 }
             }
             return;

--- a/src/main/java/org/jahia/modules/bruteforceloginprotection/core/UnbanScheduler.java
+++ b/src/main/java/org/jahia/modules/bruteforceloginprotection/core/UnbanScheduler.java
@@ -92,6 +92,9 @@ public class UnbanScheduler {
         } catch (Exception e) {
             LOGGER.warn("BFLP: unban sweep failed: {}", e.getMessage());
         }
+        // Trim the audit log periodically instead of on every write (avoids an O(n) JCR scan
+        // on the hot login-failure recording path).
+        auditLogger.trimAuditLog();
     }
 
     private void dispatchUnbanActions(BanContext ctx) {

--- a/src/main/java/org/jahia/modules/bruteforceloginprotection/core/WebhookSecretCodec.java
+++ b/src/main/java/org/jahia/modules/bruteforceloginprotection/core/WebhookSecretCodec.java
@@ -18,6 +18,12 @@ public final class WebhookSecretCodec {
         // utility
     }
 
+    /**
+     * Encrypts {@code plain} and returns the {@code {enc}}-prefixed ciphertext.
+     *
+     * @throws IllegalStateException if encryption fails — callers must not persist the secret when
+     *                               this method throws, as that would store plaintext in the .cfg.
+     */
     public static String encrypt(String plain) {
         if (plain == null) {
             return null;
@@ -25,8 +31,8 @@ public final class WebhookSecretCodec {
         try {
             return ENC_PREFIX + EncryptionUtils.passwordBaseEncrypt(plain);
         } catch (Exception e) {
-            LOGGER.warn("BFLP: failed to encrypt webhookSecret, storing plaintext fallback: {}", e.getMessage());
-            return plain;
+            LOGGER.error("BFLP: failed to encrypt webhookSecret — refusing to persist plaintext: {}", e.getMessage());
+            throw new IllegalStateException("BFLP: webhookSecret encryption failed", e);
         }
     }
 


### PR DESCRIPTION
## Summary

Remediation from a support code review covering architecture, security, code quality, and documentation.

## Changes (4 commit(s))

- fix: throw on webhookSecret encryption failure instead of persisting plaintext
- perf: move AuditLogger trimIfNeeded off the per-write hot path
- fix: shutdown IGNORE_PATTERN_EXECUTOR on BruteForceTracker bundle deactivate
- fix: replace deprecated java.net.URL constructor with URI.create().toURL()

## Test plan

- `mvn clean install` succeeds
- Cypress E2E suite executed against Jahia EE 8.2 — passing.
