### PR TITLE
build: target Java 17 + restore frontend-maven-plugin 2.0.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,9 +106,10 @@ Custom modules just need to publish an OSGi `@Component` implementing `BanAction
 ## Build
 
 ```bash
-JAVA_HOME=/usr/local/graalvm mvn clean install sonar:sonar   # Full build + SonarQube scan (needs Java 17)
-mvn clean install                                             # Full build only (Java 11 ok)
-mvn test                                                      # JUnit only
+# This module targets Java 17 (build + runtime) — build with a JDK 17 (e.g. GraalVM 17).
+JAVA_HOME=/usr/local/graalvm mvn clean install                # Full build (requires Java 17)
+JAVA_HOME=/usr/local/graalvm mvn clean install sonar:sonar    # Full build + SonarQube scan
+mvn test                                                      # JUnit only (requires Java 17)
 yarn build              # Frontend only
 yarn watch              # Frontend dev watch
 yarn lint               # ESLint (src/javascript)
@@ -116,7 +117,7 @@ yarn lint:fix           # ESLint with auto-fix
 ```
 
 - Node v22.6.0, Yarn v1.22.21 (classic, `nodeLinker: node-modules`)
-- GraalVM Java 17 at `/usr/local/graalvm/` — required for `sonar-maven-plugin:3.10.0.2594` (class file 61.0)
+- **Java 17 required** (compiler `release` 17; overrides the jahia-modules 8.2 Java 11 baseline). Jahia 8.2 runs on Java 17. GraalVM Java 17 at `/usr/local/graalvm/`.
 - SonarQube project key: `org.jahia.community:brute-force-login-protection`
 - Frontend entry: `src/javascript/index.js` → React component under `src/javascript/BruteForceLoginProtection/`, tabbed UI in `BruteForceLoginProtection/tabs/` (`GeneralTab`, `JailsTab`, `BansTab`, `AuditTab`, `IntegrationsTab`)
 - CSS modules use `bflp_` prefix (e.g. `bflp_alert--success`, `bflp_emptyState`)

--- a/pom.xml
+++ b/pom.xml
@@ -100,9 +100,7 @@
       <plugin>
         <groupId>com.github.eirslett</groupId>
         <artifactId>frontend-maven-plugin</artifactId>
-        <!-- Pinned to the 1.x line: frontend-maven-plugin 2.x requires Java 17, but this
-             module builds on Java 11 (jahia-modules 8.2 baseline; see AGENTS.md). -->
-        <version>1.15.0</version>
+        <version>2.0.0</version>
         <executions>
           <execution>
             <id>npm install node and yarn</id>
@@ -133,6 +131,15 @@
             </configuration>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <!-- This module targets Java 17 (build + runtime), overriding the Java 11
+             baseline inherited from the jahia-modules parent. Jahia 8.2 runs on Java 17. -->
+        <configuration>
+          <release>17</release>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Summary
Move brute-force-login-protection to **Java 17** (build + runtime), per decision to standardize on Java 17 for this module. Overrides the Java 11 baseline inherited from the `jahia-modules` 8.2 parent (`maven-compiler-plugin` `release` 17). Jahia 8.2 runs on Java 17, so the module loads fine.

## Why
The earlier Dependabot bump of `frontend-maven-plugin` → 2.0.0 broke the Java 11 build (the plugin requires a Java 17 JVM). Rather than pinning the plugin to the 1.x line, this adopts Java 17 so current build tooling can be used. `frontend-maven-plugin` is restored to **2.0.0**.

## Changes
- `pom.xml`: add `maven-compiler-plugin` with `<release>17</release>`; restore `frontend-maven-plugin` 2.0.0.
- `AGENTS.md`: document the Java 17 build requirement.

## Not changed
- `typescript` stays at **4.9.5**. TS 6.0's `downlevelIteration` hard-deprecation breaks Cypress spec compilation and is a Node-tooling issue, independent of the JVM.

## Test plan
- [x] `JAVA_HOME=<jdk17> mvn clean install` → BUILD SUCCESS, bytecode major version 61 (Java 17)
- [x] Full Cypress E2E against the Java 17 Jahia → **16/16 specs pass**

## ⚠️ Compatibility note
This module now requires a **Java 17** runtime; it will no longer load on a Java 11 Jahia. Merge only if all target environments run Jahia on Java 17.