### PR TITLE
harden: input validation, distributed-state atomicity, lifecycle robustness (+35 tests)

### DIFF
--- a/src/main/java/org/jahia/modules/bruteforceloginprotection/core/AuditLogger.java
+++ b/src/main/java/org/jahia/modules/bruteforceloginprotection/core/AuditLogger.java
@@ -70,8 +70,10 @@ public class AuditLogger {
                 // The periodic sweep in UnbanScheduler calls trimAuditLog() every 30 s.
                 // As a safety net, piggyback a trim every TRIM_WRITE_INTERVAL writes so the
                 // log stays bounded even under high load between sweeps.
-                if (writesSinceTrim.incrementAndGet() >= TRIM_WRITE_INTERVAL) {
-                    writesSinceTrim.set(0);
+                // CAS the reset so a concurrent write's increment isn't lost between the
+                // threshold check and the reset (which would delay the next piggyback trim).
+                long writes = writesSinceTrim.incrementAndGet();
+                if (writes >= TRIM_WRITE_INTERVAL && writesSinceTrim.compareAndSet(writes, 0)) {
                     trimIfNeeded(container);
                 }
                 return null;

--- a/src/main/java/org/jahia/modules/bruteforceloginprotection/core/BruteForceTracker.java
+++ b/src/main/java/org/jahia/modules/bruteforceloginprotection/core/BruteForceTracker.java
@@ -69,6 +69,7 @@ public class BruteForceTracker implements FailureRecorder {
         ((ThreadPoolExecutor) IGNORE_PATTERN_EXECUTOR).allowCoreThreadTimeOut(true);
     }
     private static final AtomicLong lastIgnorePatternTimeoutWarnMs = new AtomicLong(0L);
+    private static final AtomicLong lastHazelcastDownWarnMs = new AtomicLong(0L);
 
     @Reference
     private HazelcastInstanceManager hazelcastManager;
@@ -138,22 +139,35 @@ public class BruteForceTracker implements FailureRecorder {
         long now = event.getTimestampMs() > 0 ? event.getTimestampMs() : System.currentTimeMillis();
         String key = event.getIp() + "|" + jail.getName();
         IMap<String, FailureWindow> windows = hz.getMap(MAP_WINDOWS);
-        FailureWindow window = windows.get(key);
-        if (window == null) {
-            window = new FailureWindow(event.getIp(), jail.getName());
+        // The read-modify-write of the per-IP failure window must be atomic across the cluster:
+        // without the per-key lock, two concurrent failures for the same IP can both read the same
+        // window, mutate independent copies and write back, losing one increment (delayed/missed ban).
+        // The lock scope is kept tight — audit logging and ban dispatch (which can do JCR/HTTP I/O)
+        // run outside it so the key lock is never held across slow or external calls.
+        boolean banTriggered = false;
+        windows.lock(key);
+        try {
+            FailureWindow window = windows.get(key);
+            if (window == null) {
+                window = new FailureWindow(event.getIp(), jail.getName());
+            }
+            window.prune(now - (jail.getFindTimeSec() * 1000L));
+            window.add(now);
+            if (window.size() >= jail.getMaxRetry()) {
+                banTriggered = true;
+                windows.remove(key);
+            } else {
+                windows.put(key, window, jail.getFindTimeSec() * 2L, TimeUnit.SECONDS);
+            }
+        } finally {
+            windows.unlock(key);
         }
-        long cutoff = now - (jail.getFindTimeSec() * 1000L);
-        window.prune(cutoff);
-        window.add(now);
 
         auditLogger.log(AuditLogger.EVENT_FAILURE, event.getIp(), jail.getName(), event.getSourceName(),
                 "username=" + AuditLogger.sanitize(event.getUsername()));
 
-        if (window.size() >= jail.getMaxRetry()) {
+        if (banTriggered) {
             doBan(hz, event, jail, settings, now);
-            windows.remove(key);
-        } else {
-            windows.put(key, window, jail.getFindTimeSec() * 2L, TimeUnit.SECONDS);
         }
     }
 
@@ -238,7 +252,11 @@ public class BruteForceTracker implements FailureRecorder {
     }
 
     public boolean banManually(String ip, String jailName, Integer durationSeconds, String reason) {
-        if (StringUtils.isBlank(ip)) {
+        if (StringUtils.isBlank(ip) || !CidrMatcher.isIpLiteral(ip)) {
+            // Manual bans (GraphQL/Karaf) must be IP literals: a hostname or garbage value would be
+            // stored as a map/JCR key, could trigger DNS resolution on the ban-check path, and would
+            // never match a real client address. Reject it at the boundary.
+            LOGGER.warn("BFLP: refusing manual ban of non-IP value '{}'", AuditLogger.sanitize(ip));
             return false;
         }
         HazelcastInstance hz = hazelcastInstance();
@@ -253,6 +271,9 @@ public class BruteForceTracker implements FailureRecorder {
         if (settings.getMaxBanTimeSec() > 0 && banSec > settings.getMaxBanTimeSec()) {
             banSec = settings.getMaxBanTimeSec();
         }
+        // Never store a zero/negative-duration ban (a misconfigured jail ban-time would otherwise
+        // produce a ban that expires immediately and silently provides no protection).
+        banSec = Math.max(1L, banSec);
         IMap<String, BannedIp> bans = hz.getMap(MAP_BANS);
         BannedIp existing = bans.get(ip);
         int prevCount = existing != null ? existing.getBanCount() : readBanCountFromJcr(ip);
@@ -335,7 +356,16 @@ public class BruteForceTracker implements FailureRecorder {
             return false;
         }
         HazelcastInstance hz = hazelcastInstance();
-        if (hz == null) {
+        // Treat a missing OR not-running Hazelcast as "cannot enforce". This is the per-request
+        // hot path, so we deliberately fail OPEN: blocking every login because the distributed
+        // ban store is down would be a self-inflicted denial of service. We surface it with a
+        // throttled WARN so operators notice the protection gap without flooding the log.
+        if (hz == null || !hz.getLifecycleService().isRunning()) {
+            long nowMs = System.currentTimeMillis();
+            long last = lastHazelcastDownWarnMs.get();
+            if (nowMs - last > IGNORE_PATTERN_WARN_THROTTLE_MS && lastHazelcastDownWarnMs.compareAndSet(last, nowMs)) {
+                LOGGER.warn("BFLP: Hazelcast unavailable; ban enforcement temporarily disabled (fail-open)");
+            }
             return false;
         }
         IMap<String, BannedIp> bans = hz.getMap(MAP_BANS);

--- a/src/main/java/org/jahia/modules/bruteforceloginprotection/core/RegexSafetyCheck.java
+++ b/src/main/java/org/jahia/modules/bruteforceloginprotection/core/RegexSafetyCheck.java
@@ -11,6 +11,7 @@ public final class RegexSafetyCheck {
 
     public static final int MAX_PATTERN_LENGTH = 200;
     public static final int MAX_QUANTIFIERS_PER_GROUP = 2;
+    public static final int MAX_GROUP_DEPTH = 32;
 
     private RegexSafetyCheck() {
         // utility
@@ -65,7 +66,7 @@ public final class RegexSafetyCheck {
 
     private static void assertGroupQuantifierDensity(String pattern) {
         int depth = 0;
-        int[] quantsAtDepth = new int[64];
+        int[] quantsAtDepth = new int[MAX_GROUP_DEPTH + 1];
         boolean escaped = false;
         for (int i = 0; i < pattern.length(); i++) {
             char c = pattern.charAt(i);
@@ -73,8 +74,14 @@ public final class RegexSafetyCheck {
                 escaped = false;
             } else if (c == '\\' && i + 1 < pattern.length()) {
                 escaped = true;
-            } else if (c == '(' && depth + 1 < quantsAtDepth.length) {
+            } else if (c == '(') {
                 depth++;
+                if (depth > MAX_GROUP_DEPTH) {
+                    // Reject rather than silently stop tracking: extreme nesting is itself a ReDoS
+                    // smell, and letting it through would bypass the per-group quantifier check.
+                    throw new IllegalArgumentException(
+                            "Pattern group nesting exceeds " + MAX_GROUP_DEPTH);
+                }
                 quantsAtDepth[depth] = 0;
             } else if (c == ')' && depth > 0) {
                 if (quantsAtDepth[depth] > MAX_QUANTIFIERS_PER_GROUP) {

--- a/src/main/java/org/jahia/modules/bruteforceloginprotection/core/SettingsService.java
+++ b/src/main/java/org/jahia/modules/bruteforceloginprotection/core/SettingsService.java
@@ -19,6 +19,7 @@ import java.util.Dictionary;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import static org.jahia.modules.bruteforceloginprotection.BruteForceLoginProtectionConstants.*;
 
@@ -135,6 +136,7 @@ public class SettingsService {
             props.put(GlobalConfigHolder.CFG_EMAIL_ENABLED, String.valueOf(u.getEmailEnabled()));
         }
         if (u.getEmailRecipient() != null) {
+            validateEmailRecipient(u.getEmailRecipient());
             props.put(GlobalConfigHolder.CFG_EMAIL_RECIPIENT, u.getEmailRecipient());
         }
         if (u.getWebhookUrl() != null) {
@@ -142,6 +144,33 @@ public class SettingsService {
                 WebhookUrlValidator.validateUrl(u.getWebhookUrl());
             }
             props.put(GlobalConfigHolder.CFG_WEBHOOK_URL, u.getWebhookUrl());
+        }
+    }
+
+    // Lenient address shape (not RFC-complete) — enough to reject obvious garbage while accepting
+    // ordinary addresses. Used only as defense-in-depth on top of the control-char/CRLF rejection.
+    private static final Pattern EMAIL_PATTERN = Pattern.compile("^[^\\s@,]+@[^\\s@,]+\\.[^\\s@,]+$");
+
+    /**
+     * Rejects an email recipient that contains control characters / CRLF (which would otherwise be
+     * persisted to the .cfg and enable SMTP header injection in {@code EmailBanAction}) or that is
+     * not address-shaped. Supports a comma-separated list. Blank is allowed (clears the recipient).
+     */
+    private static void validateEmailRecipient(String recipient) {
+        if (StringUtils.isBlank(recipient)) {
+            return;
+        }
+        for (int i = 0; i < recipient.length(); i++) {
+            char c = recipient.charAt(i);
+            if (c < 0x20 || c == 0x7F) {
+                throw new IllegalArgumentException("Email recipient contains control characters");
+            }
+        }
+        for (String addr : recipient.split(",")) {
+            String trimmed = addr.trim();
+            if (!trimmed.isEmpty() && !EMAIL_PATTERN.matcher(trimmed).matches()) {
+                throw new IllegalArgumentException("Invalid email recipient: " + AuditLogger.sanitize(trimmed));
+            }
         }
     }
 

--- a/src/main/java/org/jahia/modules/bruteforceloginprotection/core/UnbanScheduler.java
+++ b/src/main/java/org/jahia/modules/bruteforceloginprotection/core/UnbanScheduler.java
@@ -56,45 +56,49 @@ public class UnbanScheduler {
     }
 
     public void sweep() {
+        // scheduleWithFixedDelay permanently cancels the task if its run throws, so this method must
+        // never propagate anything — catch Throwable (not just Exception) around the ENTIRE body,
+        // including the audit-log trim, so a transient failure only skips one interval.
         try {
             HazelcastInstance hz = hazelcastManager.getHazelcastInstance();
-            if (hz == null || !hazelcastManager.isRunning()) {
-                return;
-            }
-            IMap<String, BannedIp> bans = hz.getMap(MAP_BANS);
-            long now = System.currentTimeMillis();
-            Set<String> toRemove = new HashSet<>();
-            List<BannedIp> expired = new ArrayList<>();
-            for (Map.Entry<String, BannedIp> e : bans.entrySet()) {
-                BannedIp b = e.getValue();
-                if (b != null && b.isExpired(now)) {
-                    toRemove.add(e.getKey());
-                    expired.add(b);
+            if (hz != null && hazelcastManager.isRunning()) {
+                IMap<String, BannedIp> bans = hz.getMap(MAP_BANS);
+                long now = System.currentTimeMillis();
+                Set<String> toRemove = new HashSet<>();
+                List<BannedIp> expired = new ArrayList<>();
+                // Iterate a snapshot so a concurrent unbanIp()/eviction cannot make us skip an entry
+                // mid-iteration (and so each expiry dispatches its unban actions exactly once).
+                for (Map.Entry<String, BannedIp> e : new ArrayList<>(bans.entrySet())) {
+                    BannedIp b = e.getValue();
+                    if (b != null && b.isExpired(now)) {
+                        toRemove.add(e.getKey());
+                        expired.add(b);
+                    }
+                }
+                for (String key : toRemove) {
+                    bans.remove(key);
+                }
+                for (BannedIp b : expired) {
+                    tracker.removeBanFromJcr(b.getIp());
+                    auditLogger.log(AuditLogger.EVENT_UNBAN, b.getIp(), b.getJailName(), b.getSourceName(), "auto-unban");
+                    BanContext ctx = BanContext.builder()
+                            .ip(b.getIp())
+                            .jailName(b.getJailName())
+                            .sourceName(b.getSourceName())
+                            .bannedAt(b.getBannedAt())
+                            .bannedUntil(b.getBannedUntil())
+                            .banCount(b.getBanCount())
+                            .reason(b.getReason())
+                            .build();
+                    dispatchUnbanActions(ctx);
                 }
             }
-            for (String key : toRemove) {
-                bans.remove(key);
-            }
-            for (BannedIp b : expired) {
-                tracker.removeBanFromJcr(b.getIp());
-                auditLogger.log(AuditLogger.EVENT_UNBAN, b.getIp(), b.getJailName(), b.getSourceName(), "auto-unban");
-                BanContext ctx = BanContext.builder()
-                        .ip(b.getIp())
-                        .jailName(b.getJailName())
-                        .sourceName(b.getSourceName())
-                        .bannedAt(b.getBannedAt())
-                        .bannedUntil(b.getBannedUntil())
-                        .banCount(b.getBanCount())
-                        .reason(b.getReason())
-                        .build();
-                dispatchUnbanActions(ctx);
-            }
-        } catch (Exception e) {
-            LOGGER.warn("BFLP: unban sweep failed: {}", e.getMessage());
+            // Trim the audit log periodically instead of on every write (avoids an O(n) JCR scan
+            // on the hot login-failure recording path).
+            auditLogger.trimAuditLog();
+        } catch (Throwable t) {
+            LOGGER.error("BFLP: unban sweep failed; will retry on next interval", t);
         }
-        // Trim the audit log periodically instead of on every write (avoids an O(n) JCR scan
-        // on the hot login-failure recording path).
-        auditLogger.trimAuditLog();
     }
 
     private void dispatchUnbanActions(BanContext ctx) {

--- a/src/main/java/org/jahia/modules/bruteforceloginprotection/hazelcast/HazelcastInstanceManager.java
+++ b/src/main/java/org/jahia/modules/bruteforceloginprotection/hazelcast/HazelcastInstanceManager.java
@@ -65,7 +65,9 @@ public class HazelcastInstanceManager implements Runnable {
 
     private ClassLoader classLoader;
     private HazelcastInstance hazelcastInstance;
-    private Set<String> discoveredMembers;
+    // Written from both @Activate and the discovery scheduler thread, read from both — volatile
+    // for safe publication of the latest member set.
+    private volatile Set<String> discoveredMembers;
 
     @Reference(service = DiscoveryService.class,
             policy = ReferencePolicy.DYNAMIC,
@@ -144,7 +146,16 @@ public class HazelcastInstanceManager implements Runnable {
     @Deactivate
     protected void destroy(BundleContext bundleContext) {
         logger.info("BFLP: shutting down");
-        scheduler.shutdown();
+        // Wait for the discovery task to finish so it cannot touch the Hazelcast instance or
+        // bundle classloader after they are torn down below.
+        scheduler.shutdownNow();
+        try {
+            if (!scheduler.awaitTermination(5, TimeUnit.SECONDS)) {
+                logger.warn("BFLP: discovery scheduler did not terminate within 5s");
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
         try {
             bundleContext.removeBundleListener(flushClassLoaderCacheBundleListener);
         } catch (Exception e) {

--- a/src/test/java/org/jahia/modules/bruteforceloginprotection/CidrMatcherIpLiteralTest.java
+++ b/src/test/java/org/jahia/modules/bruteforceloginprotection/CidrMatcherIpLiteralTest.java
@@ -1,0 +1,44 @@
+package org.jahia.modules.bruteforceloginprotection;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Direct tests for {@link CidrMatcher#isIpLiteral(String)} — the lexical check used to keep
+ * hostnames/garbage out of code paths that must not trigger DNS resolution (X-Forwarded-For
+ * parsing and manual bans). It is a character-class gate (digits/dots, or hex/colons for IPv6),
+ * not a full range-validating parser.
+ */
+public class CidrMatcherIpLiteralTest {
+
+    @Test
+    public void acceptsIpv4Literals() {
+        assertThat(CidrMatcher.isIpLiteral("192.168.1.1")).isTrue();
+        assertThat(CidrMatcher.isIpLiteral("8.8.8.8")).isTrue();
+        assertThat(CidrMatcher.isIpLiteral("0.0.0.0")).isTrue();
+    }
+
+    @Test
+    public void acceptsIpv6Literals() {
+        assertThat(CidrMatcher.isIpLiteral("::1")).isTrue();
+        assertThat(CidrMatcher.isIpLiteral("2001:db8::1")).isTrue();
+        assertThat(CidrMatcher.isIpLiteral("fe80::1")).isTrue();
+    }
+
+    @Test
+    public void rejectsHostnames() {
+        assertThat(CidrMatcher.isIpLiteral("example.com")).isFalse();
+        assertThat(CidrMatcher.isIpLiteral("localhost")).isFalse();
+        assertThat(CidrMatcher.isIpLiteral("evil.attacker.test")).isFalse();
+    }
+
+    @Test
+    public void rejectsGarbageEmptyAndNull() {
+        assertThat(CidrMatcher.isIpLiteral("not-an-ip")).isFalse();
+        assertThat(CidrMatcher.isIpLiteral("192.168.1.1x")).isFalse();
+        assertThat(CidrMatcher.isIpLiteral("10.0.0.1 ; rm -rf")).isFalse();
+        assertThat(CidrMatcher.isIpLiteral("")).isFalse();
+        assertThat(CidrMatcher.isIpLiteral(null)).isFalse();
+    }
+}

--- a/src/test/java/org/jahia/modules/bruteforceloginprotection/actions/WebhookUrlValidatorTest.java
+++ b/src/test/java/org/jahia/modules/bruteforceloginprotection/actions/WebhookUrlValidatorTest.java
@@ -1,0 +1,99 @@
+package org.jahia.modules.bruteforceloginprotection.actions;
+
+import org.junit.Test;
+
+import java.net.InetAddress;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * SSRF-mitigation tests for {@link WebhookUrlValidator}. All cases use IP literals so the
+ * validator resolves them without real DNS, keeping the test hermetic. Forbidden cases assert
+ * an {@link IllegalArgumentException} is thrown (the exact message/reason may differ per JDK for
+ * IPv6 literals, so only the type is asserted there).
+ */
+public class WebhookUrlValidatorTest {
+
+    @Test
+    public void blankOrNullRejected() {
+        assertThatThrownBy(() -> WebhookUrlValidator.validateUrl("")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> WebhookUrlValidator.validateUrl(null)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void missingSchemeRejected() {
+        assertThatThrownBy(() -> WebhookUrlValidator.validateUrl("8.8.8.8/hook"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void nonHttpsSchemeRejected() {
+        assertThatThrownBy(() -> WebhookUrlValidator.validateUrl("ftp://8.8.8.8/"))
+                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("https");
+        assertThatThrownBy(() -> WebhookUrlValidator.validateUrl("file:///etc/passwd"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void httpRejectedByDefault() {
+        assertThatThrownBy(() -> WebhookUrlValidator.validateUrl("http://8.8.8.8/"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void userinfoRejected() {
+        assertThatThrownBy(() -> WebhookUrlValidator.validateUrl("https://user:pass@8.8.8.8/"))
+                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("userinfo");
+    }
+
+    @Test
+    public void loopbackRejected() {
+        assertThatThrownBy(() -> WebhookUrlValidator.validateUrl("https://127.0.0.1/"))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> WebhookUrlValidator.validateUrl("https://[::1]/"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void cloudMetadataAddressRejected() {
+        assertThatThrownBy(() -> WebhookUrlValidator.validateUrl("https://169.254.169.254/latest/meta-data/"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void privateIpv4RangesRejected() {
+        assertThatThrownBy(() -> WebhookUrlValidator.validateUrl("https://10.0.0.5/")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> WebhookUrlValidator.validateUrl("https://192.168.1.10/")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> WebhookUrlValidator.validateUrl("https://172.16.5.5/")).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void anyLocalAddressRejected() {
+        assertThatThrownBy(() -> WebhookUrlValidator.validateUrl("https://0.0.0.0/"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void ipv6InternalRangesRejected() {
+        // unique-local (fc00::/7) and link-local (fe80::/10)
+        assertThatThrownBy(() -> WebhookUrlValidator.validateUrl("https://[fc00::1]/")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> WebhookUrlValidator.validateUrl("https://[fd12::1]/")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> WebhookUrlValidator.validateUrl("https://[fe80::1]/")).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void ipv4MappedLoopbackRejected() {
+        assertThatThrownBy(() -> WebhookUrlValidator.validateUrl("https://[::ffff:127.0.0.1]/"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void publicHttpsAddressAccepted() {
+        InetAddress addr = WebhookUrlValidator.validateAndResolve("https://8.8.8.8/hook");
+        assertThat(addr.getHostAddress()).isEqualTo("8.8.8.8");
+        assertThatCode(() -> WebhookUrlValidator.validateUrl("https://93.184.216.34:8443/hook"))
+                .doesNotThrowAnyException();
+    }
+}

--- a/src/test/java/org/jahia/modules/bruteforceloginprotection/core/AuditLoggerSanitizeTest.java
+++ b/src/test/java/org/jahia/modules/bruteforceloginprotection/core/AuditLoggerSanitizeTest.java
@@ -1,0 +1,30 @@
+package org.jahia.modules.bruteforceloginprotection.core;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link AuditLogger#sanitize(String)} — strips CR/LF so attacker-controlled values
+ * (e.g. usernames) cannot inject forged lines into the audit trail / logs.
+ */
+public class AuditLoggerSanitizeTest {
+
+    @Test
+    public void stripsCarriageReturnAndNewline() {
+        assertThat(AuditLogger.sanitize("hello\r\nworld")).isEqualTo("helloworld");
+        assertThat(AuditLogger.sanitize("a\rb\nc")).isEqualTo("abc");
+        assertThat(AuditLogger.sanitize("user\nBAN 1.2.3.4 forged")).isEqualTo("userBAN 1.2.3.4 forged");
+    }
+
+    @Test
+    public void nullReturnsNull() {
+        assertThat(AuditLogger.sanitize(null)).isNull();
+    }
+
+    @Test
+    public void plainValueUnchanged() {
+        assertThat(AuditLogger.sanitize("admin")).isEqualTo("admin");
+        assertThat(AuditLogger.sanitize("")).isEqualTo("");
+    }
+}

--- a/src/test/java/org/jahia/modules/bruteforceloginprotection/core/BruteForceTrackerTest.java
+++ b/src/test/java/org/jahia/modules/bruteforceloginprotection/core/BruteForceTrackerTest.java
@@ -2,6 +2,7 @@ package org.jahia.modules.bruteforceloginprotection.core;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
+import com.hazelcast.core.LifecycleService;
 import org.jahia.modules.bruteforceloginprotection.hazelcast.HazelcastInstanceManager;
 import org.jahia.modules.bruteforceloginprotection.spi.BanAction;
 import org.jahia.modules.bruteforceloginprotection.spi.FailureEvent;
@@ -58,6 +59,9 @@ public class BruteForceTrackerTest {
         bansStore = new ConcurrentHashMap<>();
 
         when(hazelcastManager.getHazelcastInstance()).thenReturn(hazelcast);
+        LifecycleService lifecycleService = mock(LifecycleService.class);
+        when(hazelcast.getLifecycleService()).thenReturn(lifecycleService);
+        when(lifecycleService.isRunning()).thenReturn(true);
         when(hazelcast.<String, FailureWindow>getMap("bflp:windows")).thenReturn(windowsMap);
         when(hazelcast.<String, BannedIp>getMap("bflp:bans")).thenReturn(bansMap);
         when(hazelcast.getMap("bflp:notifMarkers")).thenReturn(mock(IMap.class));
@@ -147,6 +151,35 @@ public class BruteForceTrackerTest {
                 .requestPath("/cms/login")
                 .extras(new HashMap<>())
                 .build();
+    }
+
+    @Test
+    public void banManuallyRejectsNonIpValue() {
+        // S1: a hostname or garbage value must never be stored as a ban (no DNS lookup, no poisoning).
+        assertThat(tracker.banManually("evil.example.com", "login", 300, "reason")).isFalse();
+        assertThat(tracker.banManually("not-an-ip", null, null, null)).isFalse();
+        assertThat(bansStore).isEmpty();
+        verify(auditLogger, never()).log(eq(AuditLogger.EVENT_BAN), anyString(), anyString(), anyString(), anyString());
+    }
+
+    @Test
+    public void banManuallyWithValidIpCreatesBan() {
+        when(settingsService.getGlobalSettings()).thenReturn(activeSettings());
+        when(settingsService.getJail("login")).thenReturn(loginJail(3, 60L, 60L));
+
+        assertThat(tracker.banManually("203.0.113.7", "login", 300, "manual test")).isTrue();
+
+        assertThat(bansStore).containsKey("203.0.113.7");
+        assertThat(bansStore.get("203.0.113.7").getBannedUntil()).isGreaterThan(System.currentTimeMillis());
+    }
+
+    @Test
+    public void isIpCurrentlyBannedFailsOpenWhenHazelcastNotRunning() {
+        // R4: if the distributed store is down we fail open (do not block logins) even with a ban present.
+        when(hazelcast.getLifecycleService().isRunning()).thenReturn(false);
+        long now = System.currentTimeMillis();
+        bansStore.put("4.4.4.4", new BannedIp("4.4.4.4", "login", "manual", now, now + 60000L, 1, "x"));
+        assertThat(tracker.isIpCurrentlyBanned("4.4.4.4")).isFalse();
     }
 
     @Test

--- a/src/test/java/org/jahia/modules/bruteforceloginprotection/core/RegexSafetyCheckTest.java
+++ b/src/test/java/org/jahia/modules/bruteforceloginprotection/core/RegexSafetyCheckTest.java
@@ -1,0 +1,85 @@
+package org.jahia.modules.bruteforceloginprotection.core;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link RegexSafetyCheck}, the ReDoS lint applied to user-supplied
+ * {@code ignorePatterns}. Covers length, syntax, nested-quantifier, per-group quantifier
+ * density and group-nesting-depth (hardened) rejections, plus acceptance of safe patterns.
+ */
+public class RegexSafetyCheckTest {
+
+    @Test
+    public void nullPatternIsAllowed() {
+        assertThatCode(() -> RegexSafetyCheck.assertSafe(null)).doesNotThrowAnyException();
+    }
+
+    @Test
+    public void simpleValidPatternsAreAccepted() {
+        assertThatCode(() -> RegexSafetyCheck.assertSafe("^admin[0-9]{2,4}$")).doesNotThrowAnyException();
+        assertThatCode(() -> RegexSafetyCheck.assertSafe("([a-z]+_)[0-9]+")).doesNotThrowAnyException();
+    }
+
+    @Test
+    public void overLengthPatternRejected() {
+        assertThatThrownBy(() -> RegexSafetyCheck.assertSafe(repeat("a", RegexSafetyCheck.MAX_PATTERN_LENGTH + 1)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("exceeds");
+    }
+
+    @Test
+    public void patternAtMaxLengthAccepted() {
+        assertThatCode(() -> RegexSafetyCheck.assertSafe(repeat("a", RegexSafetyCheck.MAX_PATTERN_LENGTH)))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    public void invalidRegexSyntaxRejected() {
+        assertThatThrownBy(() -> RegexSafetyCheck.assertSafe("(unclosed["))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid regex");
+    }
+
+    @Test
+    public void nestedQuantifierRejected() {
+        // a group close followed by two stacked quantifiers is the classic catastrophic-backtracking smell
+        assertThatThrownBy(() -> RegexSafetyCheck.assertSafe("(x)*+"))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> RegexSafetyCheck.assertSafe("(y)++"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void excessiveQuantifierDensityWithinGroupRejected() {
+        assertThatThrownBy(() -> RegexSafetyCheck.assertSafe("(a+b*c+d*)"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("quantifiers");
+    }
+
+    @Test
+    public void excessiveGroupNestingRejected() {
+        // Hardening: nesting beyond MAX_GROUP_DEPTH is rejected outright rather than silently
+        // bypassing the per-group quantifier check.
+        int depth = RegexSafetyCheck.MAX_GROUP_DEPTH + 1;
+        String deeplyNested = repeat("(", depth) + "a" + repeat(")", depth);
+        assertThatThrownBy(() -> RegexSafetyCheck.assertSafe(deeplyNested))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("nesting");
+    }
+
+    @Test
+    public void moderateGroupNestingAccepted() {
+        assertThatCode(() -> RegexSafetyCheck.assertSafe("(((((a)))))")).doesNotThrowAnyException();
+    }
+
+    private static String repeat(String s, int n) {
+        StringBuilder sb = new StringBuilder(s.length() * n);
+        for (int i = 0; i < n; i++) {
+            sb.append(s);
+        }
+        return sb.toString();
+    }
+}

--- a/src/test/java/org/jahia/modules/bruteforceloginprotection/core/WebhookSecretCodecTest.java
+++ b/src/test/java/org/jahia/modules/bruteforceloginprotection/core/WebhookSecretCodecTest.java
@@ -1,0 +1,37 @@
+package org.jahia.modules.bruteforceloginprotection.core;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link WebhookSecretCodec} covering the null-safety, legacy-plaintext tolerance and
+ * {@code {enc}}-marker detection paths. These do not exercise Jahia's {@code EncryptionUtils}
+ * (which requires a running platform); the encrypt/decrypt round-trip is covered by E2E.
+ */
+public class WebhookSecretCodecTest {
+
+    @Test
+    public void encryptNullReturnsNull() {
+        assertThat(WebhookSecretCodec.encrypt(null)).isNull();
+    }
+
+    @Test
+    public void decryptNullReturnsNull() {
+        assertThat(WebhookSecretCodec.decrypt(null)).isNull();
+    }
+
+    @Test
+    public void decryptLegacyPlaintextPassesThrough() {
+        // A value without the {enc} marker (e.g. operator-pasted) must be returned unchanged.
+        assertThat(WebhookSecretCodec.decrypt("legacy-plaintext-secret")).isEqualTo("legacy-plaintext-secret");
+    }
+
+    @Test
+    public void isEncryptedDetectsMarker() {
+        assertThat(WebhookSecretCodec.isEncrypted("{enc}ciphertext")).isTrue();
+        assertThat(WebhookSecretCodec.isEncrypted("plaintext")).isFalse();
+        assertThat(WebhookSecretCodec.isEncrypted("")).isFalse();
+        assertThat(WebhookSecretCodec.isEncrypted(null)).isFalse();
+    }
+}


### PR DESCRIPTION
## Summary
Strengthens `brute-force-login-protection` across **input validation**, **distributed-state atomicity**, and **resource/lifecycle robustness**, plus **35 new unit tests** for previously-untested security-critical logic. No change to the happy-path ban flow — full E2E stays **16/16 green**.

The module was already well-hardened in the big areas (SSRF allowlist, deserialization allowlist, HMAC signing, ReDoS match timeout, X-Forwarded-For parsing, GraphQL permission gating). These changes close the remaining gaps found in a focused security/robustness review.

## Security
- **Manual ban IP validation** (`BruteForceTracker.banManually`, GraphQL `bruteForceLoginProtectionBanIp`): reject non-IP-literal input (hostnames/garbage) before storing it as a ban key — prevents DNS resolution on the ban-check path and map/JCR key poisoning.
- **Ban duration floor**: a manual ban can never be stored with a 0/negative duration (instant-expiry no-op).
- **Email recipient validation** (`SettingsService`): reject CR/LF/control characters (SMTP-header-injection defense-in-depth) and obviously malformed addresses before persisting to the `.cfg`.
- **RegexSafetyCheck group-depth cap**: reject pathologically nested groups instead of silently bypassing the per-group quantifier (ReDoS) check beyond depth 63.

## Robustness / concurrency
- **Atomic failure-window update** (`BruteForceTracker.recordEvent`): per-key Hazelcast lock around the read-modify-write closes a cross-node lost-update race that could delay or miss a ban. Lock scope is tight — never held across audit/JCR/webhook I/O.
- **Ban-check on Hazelcast outage** (`isIpCurrentlyBanned`): guards a non-running instance with a throttled WARN, **deliberately fail-open** (blocking all logins when the ban store is down would be a self-DoS).
- **UnbanScheduler resilience**: whole sweep (incl. audit-log trim) wrapped in `catch(Throwable)` + snapshot iteration, so a transient failure can't permanently cancel `scheduleWithFixedDelay` ban expiry.
- **Hazelcast deactivate** awaits discovery-scheduler termination; `discoveredMembers` made `volatile`.
- **AuditLogger** trim-counter reset via CAS (no lost increments).

## Tests (+35)
`WebhookUrlValidatorTest` (SSRF allowlist, 12), `RegexSafetyCheckTest` (ReDoS lint incl. new depth cap, 9), `CidrMatcherIpLiteralTest` (4), `WebhookSecretCodecTest` (null/legacy/marker, 4), `AuditLoggerSanitizeTest` (3), and `BruteForceTrackerTest` (+3: IP-rejection, valid-ban, fail-open).

## Test plan
- [x] `JAVA_HOME=<jdk17> mvn clean install` → **89 unit tests pass**
- [x] Full Cypress E2E (Java-17 Jahia) → **16/16 specs pass**