### PR TITLE
feat: add module-specific bruteForceLoginProtectionAdmin permission for fine-grained RBAC

### DIFF
--- a/src/javascript/BruteForceLoginProtection/register.jsx
+++ b/src/javascript/BruteForceLoginProtection/register.jsx
@@ -6,7 +6,7 @@ export default () => {
     console.debug('%c brute-force-login-protection: activation in progress', 'color: #463CBA');
     registry.add('adminRoute', 'bruteForceLoginProtection', {
         targets: ['administration-server-configuration:10'],
-        requiredPermission: 'adminUsers',
+        requiredPermission: 'bruteForceLoginProtectionAdmin',
         label: 'brute-force-login-protection:label.menu_entry',
         isSelectable: true,
         render: () => React.createElement(BruteForceLoginProtectionAdmin)

--- a/src/main/import/permissions.xml
+++ b/src/main/import/permissions.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<permissions xmlns:jcr="http://www.jcp.org/jcr/1.0">
+    <admin jcr:primaryType="jnt:permission">
+        <bruteForceLoginProtectionAdmin jcr:primaryType="jnt:permission"/>
+    </admin>
+</permissions>

--- a/src/main/java/org/jahia/modules/bruteforceloginprotection/graphql/BruteForceLoginProtectionMutationExtension.java
+++ b/src/main/java/org/jahia/modules/bruteforceloginprotection/graphql/BruteForceLoginProtectionMutationExtension.java
@@ -30,7 +30,7 @@ public class BruteForceLoginProtectionMutationExtension {
 
     @GraphQLField
     @GraphQLName("bruteForceLoginProtectionSaveGlobalSettings")
-    @GraphQLRequiresPermission("admin")
+    @GraphQLRequiresPermission("bruteForceLoginProtectionAdmin")
     @SuppressWarnings("java:S107") // GraphQL schema arity: argument names are part of the public schema
     public static Boolean saveGlobalSettings(
             @GraphQLName("activated") Boolean activated,
@@ -66,7 +66,7 @@ public class BruteForceLoginProtectionMutationExtension {
 
     @GraphQLField
     @GraphQLName("bruteForceLoginProtectionSaveJail")
-    @GraphQLRequiresPermission("admin")
+    @GraphQLRequiresPermission("bruteForceLoginProtectionAdmin")
     public static Boolean saveJail(
             @GraphQLName("name") @GraphQLNonNull String name,
             @GraphQLName("enabled") Boolean enabled,
@@ -80,7 +80,7 @@ public class BruteForceLoginProtectionMutationExtension {
 
     @GraphQLField
     @GraphQLName("bruteForceLoginProtectionDeleteJail")
-    @GraphQLRequiresPermission("admin")
+    @GraphQLRequiresPermission("bruteForceLoginProtectionAdmin")
     public static Boolean deleteJail(@GraphQLName("name") @GraphQLNonNull String name) {
         SettingsService svc = BundleUtils.getOsgiService(SettingsService.class, null);
         if (svc == null) return Boolean.FALSE;
@@ -89,7 +89,7 @@ public class BruteForceLoginProtectionMutationExtension {
 
     @GraphQLField
     @GraphQLName("bruteForceLoginProtectionUnbanIp")
-    @GraphQLRequiresPermission("admin")
+    @GraphQLRequiresPermission("bruteForceLoginProtectionAdmin")
     public static Boolean unbanIp(@GraphQLName("ip") @GraphQLNonNull String ip) {
         BruteForceTracker tracker = BundleUtils.getOsgiService(BruteForceTracker.class, null);
         if (tracker == null) return Boolean.FALSE;
@@ -98,7 +98,7 @@ public class BruteForceLoginProtectionMutationExtension {
 
     @GraphQLField
     @GraphQLName("bruteForceLoginProtectionBanIp")
-    @GraphQLRequiresPermission("admin")
+    @GraphQLRequiresPermission("bruteForceLoginProtectionAdmin")
     public static Boolean banIp(
             @GraphQLName("ip") @GraphQLNonNull String ip,
             @GraphQLName("jail") String jail,
@@ -112,7 +112,7 @@ public class BruteForceLoginProtectionMutationExtension {
     @GraphQLField
     @GraphQLName("bruteForceLoginProtectionFlush")
     @GraphQLDescription("Clear all bans + windows from cluster + JCR")
-    @GraphQLRequiresPermission("admin")
+    @GraphQLRequiresPermission("bruteForceLoginProtectionAdmin")
     public static Boolean flush() {
         BruteForceTracker tracker = BundleUtils.getOsgiService(BruteForceTracker.class, null);
         if (tracker == null) return Boolean.FALSE;
@@ -121,7 +121,7 @@ public class BruteForceLoginProtectionMutationExtension {
 
     @GraphQLField
     @GraphQLName("bruteForceLoginProtectionClearAuditLog")
-    @GraphQLRequiresPermission("admin")
+    @GraphQLRequiresPermission("bruteForceLoginProtectionAdmin")
     public static Boolean clearAuditLog() {
         AuditLogger audit = BundleUtils.getOsgiService(AuditLogger.class, null);
         if (audit == null) return Boolean.FALSE;
@@ -131,7 +131,7 @@ public class BruteForceLoginProtectionMutationExtension {
     @GraphQLField
     @GraphQLName("bruteForceLoginProtectionTestEmail")
     @GraphQLDescription("Sends a synchronous test notification using the currently persisted email settings, bypassing the per-IP throttle.")
-    @GraphQLRequiresPermission("admin")
+    @GraphQLRequiresPermission("bruteForceLoginProtectionAdmin")
     public static GqlTestResult testEmail() {
         EmailBanAction action = BundleUtils.getOsgiService(EmailBanAction.class, null);
         if (action == null) {
@@ -143,7 +143,7 @@ public class BruteForceLoginProtectionMutationExtension {
     @GraphQLField
     @GraphQLName("bruteForceLoginProtectionTestWebhook")
     @GraphQLDescription("POSTs a synchronous test payload to the currently persisted webhook URL, applying the same SSRF guard and HMAC signing as the production path.")
-    @GraphQLRequiresPermission("admin")
+    @GraphQLRequiresPermission("bruteForceLoginProtectionAdmin")
     public static GqlTestResult testWebhook() {
         WebhookBanAction action = BundleUtils.getOsgiService(WebhookBanAction.class, null);
         if (action == null) {

--- a/src/main/java/org/jahia/modules/bruteforceloginprotection/graphql/BruteForceLoginProtectionQueryExtension.java
+++ b/src/main/java/org/jahia/modules/bruteforceloginprotection/graphql/BruteForceLoginProtectionQueryExtension.java
@@ -42,7 +42,7 @@ public class BruteForceLoginProtectionQueryExtension {
 
     @GraphQLField
     @GraphQLName("bruteForceLoginProtectionGlobalSettings")
-    @GraphQLRequiresPermission("admin")
+    @GraphQLRequiresPermission("bruteForceLoginProtectionAdmin")
     public static GqlGlobalSettings globalSettings() {
         SettingsService svc = BundleUtils.getOsgiService(SettingsService.class, null);
         if (svc == null) return null;
@@ -51,7 +51,7 @@ public class BruteForceLoginProtectionQueryExtension {
 
     @GraphQLField
     @GraphQLName("bruteForceLoginProtectionJails")
-    @GraphQLRequiresPermission("admin")
+    @GraphQLRequiresPermission("bruteForceLoginProtectionAdmin")
     public static List<GqlJail> jails() {
         SettingsService svc = BundleUtils.getOsgiService(SettingsService.class, null);
         if (svc == null) return Collections.emptyList();
@@ -64,7 +64,7 @@ public class BruteForceLoginProtectionQueryExtension {
 
     @GraphQLField
     @GraphQLName("bruteForceLoginProtectionBannedIps")
-    @GraphQLRequiresPermission("admin")
+    @GraphQLRequiresPermission("bruteForceLoginProtectionAdmin")
     public static List<GqlBannedIp> bannedIps() {
         BruteForceTracker tracker = BundleUtils.getOsgiService(BruteForceTracker.class, null);
         if (tracker == null) return Collections.emptyList();
@@ -78,7 +78,7 @@ public class BruteForceLoginProtectionQueryExtension {
 
     @GraphQLField
     @GraphQLName("bruteForceLoginProtectionTrackedWindows")
-    @GraphQLRequiresPermission("admin")
+    @GraphQLRequiresPermission("bruteForceLoginProtectionAdmin")
     public static List<GqlFailureWindow> trackedWindows() {
         BruteForceTracker tracker = BundleUtils.getOsgiService(BruteForceTracker.class, null);
         if (tracker == null) return Collections.emptyList();
@@ -92,7 +92,7 @@ public class BruteForceLoginProtectionQueryExtension {
 
     @GraphQLField
     @GraphQLName("bruteForceLoginProtectionAuditLog")
-    @GraphQLRequiresPermission("admin")
+    @GraphQLRequiresPermission("bruteForceLoginProtectionAdmin")
     public static List<GqlAuditEntry> auditLog(
             @GraphQLName("limit") Integer limit) {
         AuditLogger audit = BundleUtils.getOsgiService(AuditLogger.class, null);
@@ -108,7 +108,7 @@ public class BruteForceLoginProtectionQueryExtension {
 
     @GraphQLField
     @GraphQLName("bruteForceLoginProtectionBanActions")
-    @GraphQLRequiresPermission("admin")
+    @GraphQLRequiresPermission("bruteForceLoginProtectionAdmin")
     public static List<GqlBanActionInfo> banActions() {
         BruteForceTracker tracker = BundleUtils.getOsgiService(BruteForceTracker.class, null);
         if (tracker == null) return Collections.emptyList();
@@ -126,7 +126,7 @@ public class BruteForceLoginProtectionQueryExtension {
             + "given name has been registered. Lets clients (notably e2e tests) wait for "
             + "saveGlobalSettings/saveJail mutations to finish propagating before exercising "
             + "the ban path.")
-    @GraphQLRequiresPermission("admin")
+    @GraphQLRequiresPermission("bruteForceLoginProtectionAdmin")
     public static GqlConfigReadiness configReady(@GraphQLName("jail") String jail) {
         GlobalConfigHolder global = BundleUtils.getOsgiService(GlobalConfigHolder.class, null);
         JailConfigTracker tracker = BundleUtils.getOsgiService(JailConfigTracker.class, null);
@@ -137,7 +137,7 @@ public class BruteForceLoginProtectionQueryExtension {
 
     @GraphQLField
     @GraphQLName("bruteForceLoginProtectionClusterStatus")
-    @GraphQLRequiresPermission("admin")
+    @GraphQLRequiresPermission("bruteForceLoginProtectionAdmin")
     public static GqlClusterStatus clusterStatus() {
         HazelcastInstanceManager hz = BundleUtils.getOsgiService(HazelcastInstanceManager.class, null);
         if (hz == null) return new GqlClusterStatus(false, 0);


### PR DESCRIPTION
## Summary

- Creates `src/main/import/permissions.xml` defining the `bruteForceLoginProtectionAdmin` JCR permission as a child of `admin`, enabling fine-grained RBAC for this module's GraphQL surface
- Updates all 17 `@GraphQLRequiresPermission("admin")` annotations across `BruteForceLoginProtectionQueryExtension` and `BruteForceLoginProtectionMutationExtension` to use the new specific permission
- Full admins are unaffected: JCR privilege inheritance means `admin` already includes all its child permissions; no behaviour change for existing deployments

## Motivation

The fleet previously gated all module GraphQL operations behind the generic `"admin"` permission, requiring full platform-admin rights. With this change, a non-admin role can be granted just `bruteForceLoginProtectionAdmin` to manage brute-force protection without gaining broader admin access.

## Test plan

- [ ] `mvn clean install` passes (confirmed locally — EXIT_CODE=0)
- [ ] `permissions.xml` is present in the generated `import.zip` (confirmed via `unzip -l`)
- [ ] No remaining `@GraphQLRequiresPermission("admin")` in `src/main/java` (confirmed via grep)
- [ ] Deploy to a Jahia instance and verify that a user with only `bruteForceLoginProtectionAdmin` can execute module GraphQL queries/mutations
- [ ] Verify that a full `admin` user continues to work without any extra grant