### PR TITLE
test: fine-grained permission regression tests + assignable admin role

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   </parent>
   <groupId>org.jahia.community</groupId>
   <artifactId>brute-force-login-protection</artifactId>
-  <version>3.0.1-SNAPSHOT</version>
+  <version>3.0.2-SNAPSHOT</version>
   <packaging>bundle</packaging>
   <name>Brute force login protection</name>
   <description>This is the custom module (Brute force login protection) for running on a Digital Experience Manager server.</description>

--- a/src/main/import/roles.xml
+++ b/src/main/import/roles.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<roles jcr:primaryType="jnt:roles"
+       xmlns:jcr="http://www.jcp.org/jcr/1.0"
+       xmlns:j="http://www.jahia.org/jahia/1.0"
+       xmlns:jnt="http://www.jahia.org/jahia/nt/1.0">
+
+    <brute-force-login-protection-administrator jcr:primaryType="jnt:role"
+                                                j:nodeTypes="rep:root"
+                                                j:roleGroup="server-role"
+                                                j:permissionNames="administrationAccess bruteForceLoginProtectionAdmin"
+                                                j:privilegedAccess="true">
+        <j:translation_en jcr:primaryType="jnt:translation"
+                          jcr:language="en"
+                          jcr:title="Brute Force Login Protection administrator"
+                          jcr:description="Grants access to the Brute Force Login Protection administration without requiring full server administrator rights"/>
+    </brute-force-login-protection-administrator>
+</roles>

--- a/tests/cypress/e2e/02-bruteForceLoginProtection-Permissions.cy.ts
+++ b/tests/cypress/e2e/02-bruteForceLoginProtection-Permissions.cy.ts
@@ -1,0 +1,83 @@
+import {DocumentNode} from 'graphql';
+import {createUser, deleteUser, grantRoles} from '@jahia/cypress';
+
+/**
+ * Regression tests for the fine-grained `bruteForceLoginProtectionAdmin` permission.
+ *
+ * These guard against the gate being silently removed or mismatched across the stack:
+ *  - Backend: `@GraphQLRequiresPermission("bruteForceLoginProtectionAdmin")` is enforced on every
+ *    query/mutation in BruteForceLoginProtectionQueryExtension / MutationExtension as a root-node
+ *    ACL check (`session.getNode("/").hasPermission("bruteForceLoginProtectionAdmin")`).
+ *  - Frontend: `requiredPermission: 'bruteForceLoginProtectionAdmin'` in register.jsx gates the admin route.
+ *  - RBAC content: the module ships the assignable `brute-force-login-protection-administrator` role
+ *    (src/main/import/roles.xml) granting ONLY `administrationAccess` + that permission.
+ *
+ * The "allowed" user is granted that role and nothing else — never `admin` — so the tests prove
+ * fine-grained granularity, not merely that a full administrator can pass.
+ */
+describe('Brute Force Login Protection — permission enforcement', () => {
+    const ROLE_NAME = 'brute-force-login-protection-administrator';
+    const DENIED_USER = 'bflpDeniedUser';
+    const ALLOWED_USER = 'bflpAllowedUser';
+    const PASSWORD = 'BflpPerm9PwdTest';
+    const ADMIN_PATH = '/jahia/administration/bruteForceLoginProtection';
+
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const getGlobalSettings: DocumentNode = require('graphql-tag/loader!../fixtures/graphql/query/getGlobalSettings.graphql');
+
+    const errorsOf = (result: {graphQLErrors?: Array<{message: string}>; errors?: Array<{message: string}>}) =>
+        result.graphQLErrors ?? result.errors ?? [];
+
+    const queryGlobalSettingsAs = (username: string) => {
+        cy.apolloClient({username, password: PASSWORD});
+        return cy.apollo({query: getGlobalSettings});
+    };
+
+    before(() => {
+        cy.login();
+        createUser(DENIED_USER, PASSWORD);
+        createUser(ALLOWED_USER, PASSWORD);
+        // The annotation resolves the permission on the JCR root node, so grant the
+        // module-shipped single-permission role on `/`.
+        grantRoles('/', [ROLE_NAME], ALLOWED_USER, 'USER');
+    });
+
+    after(() => {
+        cy.apolloClient(); // reset the current Apollo client back to root
+        cy.login();
+        deleteUser(DENIED_USER);
+        deleteUser(ALLOWED_USER);
+    });
+
+    describe('GraphQL API authorization', () => {
+        it('denies the gated query for a user without the permission', () => {
+            queryGlobalSettingsAs(DENIED_USER).then((result: never) => {
+                const errs = errorsOf(result);
+                expect(errs, 'denial errors').to.have.length.greaterThan(0);
+                expect(errs.map((e: {message: string}) => e.message).join(' ')).to.contain('Permission denied');
+            });
+        });
+
+        it('allows the gated query for a user granted only the module permission', () => {
+            queryGlobalSettingsAs(ALLOWED_USER).then((result: never) => {
+                expect(errorsOf(result), 'should have no errors').to.have.length(0);
+                expect((result as {data: {bruteForceLoginProtectionGlobalSettings: {activated: boolean}}})
+                    .data.bruteForceLoginProtectionGlobalSettings).to.have.property('activated');
+            });
+        });
+    });
+
+    describe('Admin UI authorization', () => {
+        it('hides the admin panel from a user without the permission', () => {
+            cy.login(DENIED_USER, PASSWORD);
+            cy.visit(ADMIN_PATH, {failOnStatusCode: false});
+            cy.contains('button', /Flush all/i).should('not.exist');
+        });
+
+        it('shows the admin panel to a user granted only the module permission', () => {
+            cy.login(ALLOWED_USER, PASSWORD);
+            cy.visit(ADMIN_PATH);
+            cy.contains('button', /Flush all/i).should('be.visible');
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Adds regression coverage for the `bruteForceLoginProtectionAdmin` permission gate and ships an assignable least-privilege admin role, so the gate cannot be silently dropped or mismatched between the backend (`@GraphQLRequiresPermission`), the frontend admin route (`requiredPermission` in register.jsx), and the RBAC content.

### Changes

- **`src/main/import/roles.xml`** (new): ships a server role `brute-force-login-protection-administrator` granting only `administrationAccess bruteForceLoginProtectionAdmin` — not full `admin`. Lets the module's admin UI + GraphQL API be delegated with least privilege.
- **`tests/cypress/e2e/02-bruteForceLoginProtection-Permissions.cy.ts`** (new): 4 tests proving fine-grained granularity. The "allowed" user is granted only the module role, never `admin`.
  - GraphQL **deny** — user without the permission gets `Permission denied` on the gated `bruteForceLoginProtectionGlobalSettings` query.
  - GraphQL **allow** — user granted only the module role reads global settings with no errors.
  - Admin UI **hidden** — `Flush all` panel control absent for the denied user.
  - Admin UI **shown** — panel renders for the user granted only the module role.
- **`pom.xml`**: version bump `3.0.1-SNAPSHOT` -> `3.0.2-SNAPSHOT` so the new `roles.xml` import content is re-imported on deploy.

## Test plan

- [x] `mvn -q clean install -DskipTests` (Java 17) — builds jar including roles.xml
- [x] `./ci.build.sh && ./ci.startup.sh` -> **20/20 specs pass** (16 existing + 4 new permission tests), 0 failures
- [x] Jahia license health clean (0 `Premature end of file` / null license-package log hits)