### PR TITLE
fix: terminate Hazelcast on deactivate — module updates no longer hang on stuck partition migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.1.1-SNAPSHOT] — Unreleased
 
-- (nothing yet)
+### Fixed
+
+- **Module update no longer hangs on Hazelcast partition migrations:** on bundle stop the module now *terminates* its dedicated Hazelcast member instead of performing a graceful shutdown. Graceful shutdown blocked the OSGi bundle refresh until all partition replicas were migrated — which could stall indefinitely (`Remaining migration tasks in queue => N … completedMigrations=0`) when the base+2 port was partially firewalled or the cluster could not repartition, freezing production module updates. Safe because all Hazelcast state is reconstructible: bans are JCR-mirrored and restored at startup, failure windows are transient (see ADR 0005).
+
+### Changed
+
+- **Docs:** README gains an "Updating the module in a cluster" procedure (stop-everywhere → update → start, plus the bidirectional base+2 port requirement); new ADR 0005 records the terminate-on-deactivate decision.
 
 ## [3.1.0] — 2026-07-02
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,28 @@ OSGi `ConfigurationAdmin` storage is per-node. In a Jahia cluster you must eithe
 
 No additional Hazelcast broadcasting of settings is performed by the module.
 
+### Updating the module in a cluster
+
+The recommended procedure for updating (or uninstalling) the module on a multi-node
+cluster is **stop everywhere first, then update, then start**:
+
+1. Stop (or uninstall) the module bundle on **all** nodes. The last member to stop has
+   no migration targets, so every stop returns immediately.
+2. Deploy the new version on all nodes.
+3. Start the module everywhere. Each node re-joins the dedicated Hazelcast cluster and
+   restores active bans from the JCR mirror (startup reconciliation, ADR 0004).
+
+Rolling node-by-node updates also work — since 3.1.1 the module *terminates* its
+Hazelcast member on bundle stop instead of waiting for partition migrations
+(ADR 0005), so an update can no longer hang on `Remaining migration tasks in
+queue => N` when the base+2 port is partially firewalled or the cluster cannot
+repartition. The trade-off is a brief loss of replica redundancy for state that is
+reconstructible anyway (bans are JCR-mirrored; failure windows are transient).
+
+Whatever the procedure, make sure the module's Hazelcast port (Jahia's
+`cluster.hazelcast.bindPort` + 2, e.g. 7862 when Jahia uses 7860) is open **in both
+directions** between all cluster nodes.
+
 ### Webhook receiver guidance
 
 When verifying the `X-BFLP-Signature` header on the receiver side, **always use a constant-time

--- a/docs/adr/0005-terminate-hazelcast-on-deactivate.md
+++ b/docs/adr/0005-terminate-hazelcast-on-deactivate.md
@@ -1,0 +1,23 @@
+# ADR 0005: Terminate (Not Gracefully Shut Down) Hazelcast on Bundle Deactivation
+
+**Status:** Accepted
+
+**Date:** 2026-07-02
+
+**Context:** On bundle stop, `HazelcastInstanceManager` originally called `HazelcastInstance.shutdown()` — Hazelcast's *graceful* shutdown, which blocks until every partition replica owned by the leaving member has been migrated to the remaining cluster members, capped by `hazelcast.graceful.shutdown.max.wait` (600 s by default). In production, module updates were observed to hang with the surviving node logging `Remaining migration tasks in queue => N … completedMigrations=0` indefinitely: the queued migrations never execute (typical causes: the base+2 port is firewalled in one direction between nodes, or the leaving bundle's classloader is being torn down mid-update so migration serialization cannot proceed). Because the OSGi `@Deactivate` method blocks inside `shutdown()`, the Felix bundle refresh — and therefore the whole module update — stalls with it.
+
+**Decision:** Call `HazelcastInstance.getLifecycleService().terminate()` on deactivation instead of `shutdown()`. Terminate leaves the cluster immediately without waiting for replica migration.
+
+**Rationale:** Graceful shutdown exists to avoid losing the leaving member's share of the distributed data. This module does not need that guarantee, because none of its Hazelcast state is authoritative-and-irrecoverable:
+
+- `bflp:bans` is mirrored to JCR on every ban and restored by the startup reconciliation pass (ADR 0004). A ban whose replica is lost during a member's departure is re-seeded from JCR when the member returns; the other members' own replicas are untouched.
+- `bflp:windows` holds transient sliding-window failure counters that rebuild naturally within one `findTime` window.
+- `bflp:notifMarkers` only throttles notifications; losing a marker means at most one duplicate email/webhook.
+
+This is the same trade-off already accepted for reads in ADR 0002 (fail-open): availability of the platform — here, the ability to update the module without hanging a production node — outweighs perfect continuity of reconstructible protection state.
+
+**Consequences:**
+
+- Module updates and restarts no longer block on cluster repartitioning; bundle stop is immediate.
+- A member's departure may briefly reduce replica redundancy until Hazelcast repartitions among the remaining members — acceptable per the rationale above.
+- Rolling updates remain supported, but the recommended procedure is still stop-everywhere → update → start (see README "Updating the module in a cluster"), which avoids mixed-version members entirely.

--- a/src/main/java/org/jahia/community/bruteforceloginprotection/hazelcast/HazelcastInstanceManager.java
+++ b/src/main/java/org/jahia/community/bruteforceloginprotection/hazelcast/HazelcastInstanceManager.java
@@ -181,9 +181,17 @@ public class HazelcastInstanceManager implements Runnable {
         HazelcastInstance hz = hazelcastInstance.get();
         if (hz != null) {
             try {
-                hz.shutdown();
+                // terminate(), NOT shutdown(): graceful shutdown blocks until every partition
+                // replica owned by this member has been migrated to the rest of the cluster.
+                // When those migrations stall (firewalled base+2 port, classloader teardown
+                // mid-update, ...) the bundle stop — and therefore the whole module update —
+                // hangs for up to hazelcast.graceful.shutdown.max.wait (600s by default).
+                // Skipping replica migration is safe here: bans are mirrored to JCR and
+                // restored by the startup reconciliation pass, and failure windows are
+                // transient counters. See ADR 0005.
+                hz.getLifecycleService().terminate();
             } catch (Exception e) {
-                logger.debug("BFLP: error shutting down hazelcast", e);
+                logger.debug("BFLP: error terminating hazelcast", e);
             }
             hazelcastInstance.set(null);
         }

--- a/src/test/java/org/jahia/community/bruteforceloginprotection/hazelcast/HazelcastInstanceManagerShutdownTest.java
+++ b/src/test/java/org/jahia/community/bruteforceloginprotection/hazelcast/HazelcastInstanceManagerShutdownTest.java
@@ -1,0 +1,77 @@
+package org.jahia.community.bruteforceloginprotection.hazelcast;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.LifecycleService;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.osgi.framework.BundleContext;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the deactivation path of {@link HazelcastInstanceManager}.
+ *
+ * The module MUST terminate (not gracefully shut down) its Hazelcast instance on bundle stop:
+ * graceful shutdown blocks until all partition replicas owned by the leaving member have been
+ * migrated, which can stall indefinitely (observed in production during module updates) and
+ * hangs the whole OSGi bundle refresh. All module state in Hazelcast is reconstructible —
+ * bans from the JCR mirror, windows are transient — so skipping replica migration is safe
+ * (see ADR 0005).
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class HazelcastInstanceManagerShutdownTest {
+
+    @Mock
+    private HazelcastInstance hz;
+
+    @Mock
+    private LifecycleService lifecycleService;
+
+    @Mock
+    private BundleContext bundleContext;
+
+    @SuppressWarnings("unchecked")
+    private static void injectInstance(HazelcastInstanceManager manager, HazelcastInstance hz) throws Exception {
+        Field f = HazelcastInstanceManager.class.getDeclaredField("hazelcastInstance");
+        f.setAccessible(true);
+        ((AtomicReference<HazelcastInstance>) f.get(manager)).set(hz);
+    }
+
+    @Test
+    public void destroy_terminatesInsteadOfGracefulShutdown() throws Exception {
+        HazelcastInstanceManager manager = new HazelcastInstanceManager();
+        injectInstance(manager, hz);
+        when(hz.getLifecycleService()).thenReturn(lifecycleService);
+
+        manager.destroy(bundleContext);
+
+        verify(lifecycleService).terminate();
+        verify(hz, never()).shutdown();
+        assertThat(manager.getHazelcastInstance()).isNull();
+    }
+
+    @Test
+    public void destroy_withoutInstance_doesNotThrow() {
+        HazelcastInstanceManager manager = new HazelcastInstanceManager();
+        assertThatCode(() -> manager.destroy(bundleContext)).doesNotThrowAnyException();
+    }
+
+    @Test
+    public void destroy_terminateFailure_isSwallowed() throws Exception {
+        HazelcastInstanceManager manager = new HazelcastInstanceManager();
+        injectInstance(manager, hz);
+        when(hz.getLifecycleService()).thenThrow(new IllegalStateException("already down"));
+
+        assertThatCode(() -> manager.destroy(bundleContext)).doesNotThrowAnyException();
+        assertThat(manager.getHazelcastInstance()).isNull();
+    }
+}


### PR DESCRIPTION
## Problem

Production module updates hang, with the surviving node logging in a loop:

```
INFO [InternalPartitionService] - [10.x.x.x]:7862 [brute-force-login-protection-bflp] [3.12.13]
Remaining migration tasks in queue => 2. (… completedMigrations=0 …)
```

Root cause: `HazelcastInstanceManager.destroy()` called `hz.shutdown()` — Hazelcast's *graceful* shutdown, which blocks the OSGi bundle stop until every partition replica of the leaving member is migrated (capped by `hazelcast.graceful.shutdown.max.wait`, 600 s default). When those migrations stall (base+2 port firewalled in one direction, bundle classloader teardown mid-update), Felix's bundle refresh — and therefore the whole module update — hangs with it.

## Fix

Call `getLifecycleService().terminate()` on deactivation. Immediate cluster departure, no migration wait. This is safe because none of the module's Hazelcast state is authoritative-and-irrecoverable:

- `bflp:bans` — JCR-mirrored, restored by startup reconciliation (ADR 0004)
- `bflp:windows` — transient sliding-window counters, rebuild within one `findTime`
- `bflp:notifMarkers` — worst case one duplicate notification

Same availability-over-continuity trade-off as ADR 0002 (fail-open reads), now recorded as **ADR 0005**.

## Also included

- README: new "Updating the module in a cluster" section (recommended stop-everywhere → update → start procedure; bidirectional base+2 port requirement)
- CHANGELOG entry under 3.1.1-SNAPSHOT

## Test plan

- [x] New `HazelcastInstanceManagerShutdownTest`: `destroy()` calls `terminate()` and never `shutdown()`; null-instance and terminate-failure paths don't throw
- [x] Full unit suite green (`mvn test`)